### PR TITLE
fix(installer): move framework files under .teamwork/ and use explicit doc allowlist

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -5,16 +5,16 @@ Teamwork is an agent-native development template for AI-human collaboration usin
 ## Setup
 
 - Read `MEMORY.md` at session start for current project context.
-- Identify your role and read the corresponding file in `agents/roles/` (planner, architect, coder, tester, reviewer, security-auditor, documenter, orchestrator).
-- **If no role is specified:** Use `docs/role-selector.md`. Quick defaults: implementation → Coder, planning → Planner, review → Reviewer, multi-role → Planner.
-- Read `docs/conventions.md` for coding standards, commit format, and PR rules.
-- Check `docs/architecture.md` for prior design decisions (ADRs).
-- Use terminology from `docs/glossary.md`.
-- For multi-step tasks, follow the relevant workflow in `agents/workflows/`.
+- Identify your role and read the corresponding file in `.teamwork/agents/roles/` (planner, architect, coder, tester, reviewer, security-auditor, documenter, orchestrator).
+- **If no role is specified:** Use `.teamwork/docs/role-selector.md`. Quick defaults: implementation → Coder, planning → Planner, review → Reviewer, multi-role → Planner.
+- Read `.teamwork/docs/conventions.md` for coding standards, commit format, and PR rules.
+- Check `.teamwork/docs/architecture.md` for prior design decisions (ADRs).
+- Use terminology from `.teamwork/docs/glossary.md`.
+- For multi-step tasks, follow the relevant workflow in `.teamwork/agents/workflows/`.
 
 ## Rules
 
-1. Read your role file in `agents/roles/` before starting any work.
+1. Read your role file in `.teamwork/agents/roles/` before starting any work.
 2. Make minimal changes — only modify what the task requires.
 3. Do not refactor unrelated code or fix unrelated issues.
 4. Run all tests before and after making changes.
@@ -23,7 +23,7 @@ Teamwork is an agent-native development template for AI-human collaboration usin
 7. One task per PR. Keep PRs focused and small (~300 lines, ~10 files max).
 8. Respect role boundaries — if your role says "never write code," don't.
 9. Update documentation when changes affect behavior or APIs.
-10. Check ADRs in `docs/architecture.md` before proposing structural changes.
+10. Check ADRs in `.teamwork/docs/architecture.md` before proposing structural changes.
 
 ## Escalation
 
@@ -39,16 +39,21 @@ Stop and ask the human when:
 
 ```
 MEMORY.md           — Project context (read at session start)
-agents/roles/       — Role definitions (read yours first)
-agents/workflows/   — Workflow guides (feature, bugfix, refactor, hotfix, security-response, dependency-update, documentation, spike, release, rollback)
-.teamwork/          — Orchestration state (config, state, handoffs, memory, metrics)
-docs/conventions.md — Coding standards
-docs/architecture.md — Architecture decisions
-docs/protocols.md   — Coordination protocol specification
-docs/glossary.md    — Terminology
-docs/conflict-resolution.md — Resolving conflicting instructions
-docs/secrets-policy.md — Secrets and credentials policy
-docs/cost-policy.md — AI agent cost guidelines
+.teamwork/
+  agents/roles/     — Role definitions (read yours first)
+  agents/workflows/ — Workflow guides (feature, bugfix, refactor, hotfix, security-response, dependency-update, documentation, spike, release, rollback)
+  docs/conventions.md — Coding standards
+  docs/architecture.md — Architecture decisions
+  docs/protocols.md — Coordination protocol specification
+  docs/glossary.md  — Terminology
+  docs/conflict-resolution.md — Resolving conflicting instructions
+  docs/secrets-policy.md — Secrets and credentials policy
+  docs/cost-policy.md — AI agent cost guidelines
+  config.yaml       — Orchestration settings
+  state/            — Workflow state files
+  handoffs/         — Handoff artifacts between roles
+  memory/           — Structured project memory
+  metrics/          — Agent activity logs (gitignored)
 ```
 
 ## Model Selection
@@ -59,7 +64,7 @@ After identifying your role, check its **Model Requirements** section for the re
 - **Lower tier needed:** Proceed normally.
 - **Sub-agents available:** Route each role to the right model tier. Act as a router and dispatch sub-agents as needed.
 
-See `docs/role-selector.md` for tier-to-role mapping.
+See `.teamwork/docs/role-selector.md` for tier-to-role mapping.
 
 ## Protocol Integration
 
@@ -67,5 +72,5 @@ When working in a tracked workflow:
 1. **Start:** Check `.teamwork/state/` for your workflow. Read the previous handoff from `.teamwork/handoffs/<workflow-id>/`.
 2. **End:** Write your handoff artifact to `.teamwork/handoffs/<workflow-id>/<step>-<role>.md`. Update the state file.
 3. **Memory:** Check `.teamwork/memory/` for relevant patterns. Add new learnings when applicable.
-4. **Format:** Follow `docs/protocols.md` for all file formats.
+4. **Format:** Follow `.teamwork/docs/protocols.md` for all file formats.
 5. **Ad-hoc tasks:** Skip protocol integration if not part of a tracked workflow.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Teamwork is an agent-native development template that structures AI-human collab
 
 0. **Read project context.** Start every session by reading `MEMORY.md` for current project state, recent decisions, and active context.
 
-1. **Identify your role.** Determine which role you are performing and read the corresponding file in `agents/roles/`:
+1. **Identify your role.** Determine which role you are performing and read the corresponding file in `.teamwork/agents/roles/`:
    - `planner.md` — Break goals into tasks. Never write code.
    - `architect.md` — Design systems, write ADRs. Never write code.
    - `coder.md` — Implement tasks, write tests, open PRs.
@@ -16,11 +16,11 @@ Teamwork is an agent-native development template that structures AI-human collab
    - `documenter.md` — Keep documentation accurate and current.
    - `orchestrator.md` — Coordinate workflows, dispatch roles. Never write code.
 
-   **If no role is specified:** Use `docs/role-selector.md` to determine the right role from the task. Quick defaults: implementation tasks → Coder, planning/scoping → Planner, code review → Reviewer, multi-role tasks → Planner (break it down first).
-2. **Read the conventions.** Review `docs/conventions.md` for coding standards, branch naming, commit format, and PR requirements.
-3. **Understand the architecture.** Check `docs/architecture.md` for prior design decisions (ADRs) before proposing structural changes.
-4. **Learn the vocabulary.** Use terminology as defined in `docs/glossary.md`.
-5. **Check for workflows.** For multi-step tasks, see `agents/workflows/` for step-by-step guides (feature, bugfix, refactor, hotfix, security-response, dependency-update, documentation, spike, release).
+   **If no role is specified:** Use `.teamwork/docs/role-selector.md` to determine the right role from the task. Quick defaults: implementation tasks → Coder, planning/scoping → Planner, code review → Reviewer, multi-role tasks → Planner (break it down first).
+2. **Read the conventions.** Review `.teamwork/docs/conventions.md` for coding standards, branch naming, commit format, and PR requirements.
+3. **Understand the architecture.** Check `.teamwork/docs/architecture.md` for prior design decisions (ADRs) before proposing structural changes.
+4. **Learn the vocabulary.** Use terminology as defined in `.teamwork/docs/glossary.md`.
+5. **Check for workflows.** For multi-step tasks, see `.teamwork/agents/workflows/` for step-by-step guides (feature, bugfix, refactor, hotfix, security-response, dependency-update, documentation, spike, release).
 
 ## Key Rules
 
@@ -29,7 +29,7 @@ Teamwork is an agent-native development template that structures AI-human collab
 - **Conventional commits.** Use the format: `type(scope): description` (e.g., `feat(auth): add token refresh`).
 - **One task per PR.** Keep pull requests focused on a single task or change.
 - **Follow role boundaries.** If your role says "never write code" or "never modify code," respect that constraint.
-- **Check for workflow files.** If a multi-step workflow applies (feature, bugfix, refactor, hotfix, security-response, dependency-update, documentation, spike, release), check `agents/workflows/` for step-by-step guidance.
+- **Check for workflow files.** If a multi-step workflow applies (feature, bugfix, refactor, hotfix, security-response, dependency-update, documentation, spike, release), check `.teamwork/agents/workflows/` for step-by-step guidance.
 
 ## When to Escalate
 
@@ -45,16 +45,20 @@ Stop and ask the human when:
 
 ```
 MEMORY.md             — Project context (read at session start)
-agents/roles/         — Role definitions (read yours before starting)
-agents/workflows/     — Multi-step workflow guides
-.teamwork/            — Orchestration state (handoffs, memory, metrics)
-docs/conventions.md   — Coding standards and project conventions
-docs/architecture.md  — Architecture decisions (ADRs)
-docs/protocols.md     — Coordination protocol specification
-docs/glossary.md      — Project terminology
-docs/conflict-resolution.md — Resolving conflicting instructions
-docs/secrets-policy.md — Rules for handling secrets and credentials
-docs/cost-policy.md   — Guidelines for managing AI agent costs
+.teamwork/
+  agents/roles/       — Role definitions (read yours before starting)
+  agents/workflows/   — Multi-step workflow guides
+  docs/conventions.md — Coding standards and project conventions
+  docs/architecture.md — Architecture decisions (ADRs)
+  docs/protocols.md   — Coordination protocol specification
+  docs/glossary.md    — Project terminology
+  docs/conflict-resolution.md — Resolving conflicting instructions
+  docs/secrets-policy.md — Rules for handling secrets and credentials
+  docs/cost-policy.md — Guidelines for managing AI agent costs
+  state/              — Workflow state files
+  handoffs/           — Handoff artifacts between roles
+  memory/             — Structured project memory
+  metrics/            — Agent activity logs (gitignored)
 ```
 
 ## Model Selection
@@ -65,7 +69,7 @@ After identifying your role, check its **Model Requirements** section for the re
 - **If the role needs a lower tier than your current model:** Proceed normally. Being overpowered is fine — just less cost-efficient.
 - **If you can spawn sub-agents:** Use the tier system to run each role at the right model level. Act as a router on a standard model and dispatch premium or fast sub-agents as needed.
 
-See `docs/role-selector.md` for the full tier-to-role mapping table.
+See `.teamwork/docs/role-selector.md` for the full tier-to-role mapping table.
 
 ## Protocol Integration
 
@@ -82,7 +86,7 @@ When working in a workflow, integrate with the `.teamwork/` protocol system:
 - Reference the handoff from the previous step — it contains the context, decisions, and artifacts you need.
 
 ### At Session End
-1. Write a handoff artifact to `.teamwork/handoffs/<workflow-id>/<step>-<role>.md` following the format in `docs/protocols.md`.
+1. Write a handoff artifact to `.teamwork/handoffs/<workflow-id>/<step>-<role>.md` following the format in `.teamwork/docs/protocols.md`.
 2. Update the workflow state file in `.teamwork/state/<workflow-id>.yaml` — record your step as completed and set the next step/role.
 3. If you learned something broadly applicable, add it to the relevant file in `.teamwork/memory/` (patterns, antipatterns, decisions, or feedback).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Teamwork is an agent-native development template that structures AI-human collab
 
 0. **Read project context.** Start every session by reading `MEMORY.md` for current project state, recent decisions, and active context.
 
-1. **Identify your role.** Determine which role you are performing and read the matching file in `agents/roles/`:
+1. **Identify your role.** Determine which role you are performing and read the matching file in `.teamwork/agents/roles/`:
    - `planner.md` — Break goals into tasks. Never write code.
    - `architect.md` — Design systems, write ADRs. Never write code.
    - `coder.md` — Implement tasks, write tests, open PRs.
@@ -16,17 +16,17 @@ Teamwork is an agent-native development template that structures AI-human collab
    - `documenter.md` — Keep documentation accurate and current.
    - `orchestrator.md` — Coordinate workflows, dispatch roles. Never write code.
 
-   **If no role is specified:** Use `docs/role-selector.md` to determine the right role from the task. Quick defaults: implementation tasks → Coder, planning/scoping → Planner, code review → Reviewer, multi-role tasks → Planner (break it down first).
+   **If no role is specified:** Use `.teamwork/docs/role-selector.md` to determine the right role from the task. Quick defaults: implementation tasks → Coder, planning/scoping → Planner, code review → Reviewer, multi-role tasks → Planner (break it down first).
 
-2. **Read the conventions.** `docs/conventions.md` defines coding standards, branch naming (`feature/`, `bugfix/`, `refactor/`), conventional commit format, PR requirements, file naming, and directory structure.
+2. **Read the conventions.** `.teamwork/docs/conventions.md` defines coding standards, branch naming (`feature/`, `bugfix/`, `refactor/`), conventional commit format, PR requirements, file naming, and directory structure.
 
-3. **Check architecture decisions.** `docs/architecture.md` contains ADRs documenting prior design decisions and their rationale. Read relevant ADRs before proposing structural changes.
+3. **Check architecture decisions.** `.teamwork/docs/architecture.md` contains ADRs documenting prior design decisions and their rationale. Read relevant ADRs before proposing structural changes.
 
-4. **Use correct terminology.** `docs/glossary.md` defines project terms (role, workflow, handoff, escalation, etc.). Use these terms consistently.
+4. **Use correct terminology.** `.teamwork/docs/glossary.md` defines project terms (role, workflow, handoff, escalation, etc.). Use these terms consistently.
 
 ## Workflows
 
-For multi-step tasks, check `agents/workflows/` for structured guides:
+For multi-step tasks, check `.teamwork/agents/workflows/` for structured guides:
 - `feature.md` — Adding new functionality
 - `bugfix.md` — Diagnosing and fixing bugs
 - `refactor.md` — Restructuring existing code
@@ -66,23 +66,23 @@ Stop and ask the human when:
 
 ```
 MEMORY.md               — Project context (read at session start)
-agents/
-  roles/              — Role definitions (8 core — read yours first)
-  workflows/          — Step-by-step workflow guides
 .teamwork/
+  agents/
+    roles/              — Role definitions (8 core — read yours first)
+    workflows/          — Step-by-step workflow guides
+  docs/
+    conventions.md      — Coding standards and project conventions
+    architecture.md     — Architecture Decision Records (ADRs)
+    protocols.md        — Coordination protocol specification
+    glossary.md         — Terminology definitions
+    conflict-resolution.md — How to resolve conflicting instructions
+    secrets-policy.md   — Rules for handling secrets and credentials
+    cost-policy.md      — Guidelines for managing AI agent costs
   config.yaml         — Orchestration settings
   state/              — Workflow state files (one per active workflow)
   handoffs/           — Handoff artifacts between roles
   memory/             — Structured project memory
   metrics/            — Agent activity logs (gitignored)
-docs/
-  conventions.md      — Coding standards and project conventions
-  architecture.md     — Architecture Decision Records (ADRs)
-  protocols.md        — Coordination protocol specification
-  glossary.md         — Terminology definitions
-  conflict-resolution.md — How to resolve conflicting instructions
-  secrets-policy.md   — Rules for handling secrets and credentials
-  cost-policy.md      — Guidelines for managing AI agent costs
 ```
 
 ## Model Selection
@@ -93,7 +93,7 @@ After identifying your role, check its **Model Requirements** section for the re
 - **If the role needs a lower tier than your current model:** Proceed normally. Being overpowered is fine — just less cost-efficient.
 - **If you can spawn sub-agents:** Use the tier system to run each role at the right model level. Act as a router on a standard model and dispatch premium or fast sub-agents as needed.
 
-See `docs/role-selector.md` for the full tier-to-role mapping table.
+See `.teamwork/docs/role-selector.md` for the full tier-to-role mapping table.
 
 ## Protocol Integration
 
@@ -106,7 +106,7 @@ When working in a workflow, integrate with the `.teamwork/` protocol system:
 4. Check `.teamwork/memory/` for patterns and decisions relevant to your domain.
 
 ### At Session End
-1. Write a handoff artifact to `.teamwork/handoffs/<workflow-id>/<step>-<role>.md` per `docs/protocols.md`.
+1. Write a handoff artifact to `.teamwork/handoffs/<workflow-id>/<step>-<role>.md` per `.teamwork/docs/protocols.md`.
 2. Update the workflow state file in `.teamwork/state/<workflow-id>.yaml` — record your step as completed.
 3. If you learned something broadly applicable, add it to `.teamwork/memory/`.
 

--- a/agents/roles/orchestrator.md
+++ b/agents/roles/orchestrator.md
@@ -29,7 +29,7 @@ You are the Orchestrator. You coordinate the workflow state machine — initiali
 ## Inputs
 
 - A human goal or directive describing what needs to be accomplished
-- Workflow definitions from `agents/workflows/` that specify steps, roles, and transitions
+- Workflow definitions from `.teamwork/agents/workflows/` that specify steps, roles, and transitions
 - Current state files from `.teamwork/state/` tracking active workflow progress
 - Handoff artifacts from `.teamwork/handoffs/` produced by roles completing their steps
 - Quality gate results indicating whether a step's outputs meet the required bar
@@ -65,7 +65,7 @@ You are the Orchestrator. You coordinate the workflow state machine — initiali
 - **Follow the workflow definitions exactly.** Do not skip steps, reorder steps, or invent steps unless the workflow definition or `.teamwork/config.yaml` explicitly allows it.
 - **When a quality gate fails, keep the workflow at the current step.** Do not advance. Re-dispatch the responsible role with feedback on what failed and what must be corrected.
 - **When a blocker is raised, set the workflow status to `blocked` and escalate.** Do not let blocked workflows sit silently — escalate within one cycle.
-- **Reference `docs/protocols.md` for all file formats and conventions.** State files, handoff artifacts, and metrics entries must follow the defined schemas.
+- **Reference `.teamwork/docs/protocols.md` for all file formats and conventions.** State files, handoff artifacts, and metrics entries must follow the defined schemas.
 
 ## Quality Bar
 

--- a/agents/workflows/bugfix.md
+++ b/agents/workflows/bugfix.md
@@ -33,7 +33,7 @@ was expected, and any steps to reproduce.
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human/Triager → Planner**
 - Bug report issue with severity label (critical / high / medium / low)

--- a/agents/workflows/dependency-update.md
+++ b/agents/workflows/dependency-update.md
@@ -36,7 +36,7 @@ A dependency update is identified through one of:
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Initiator → Dependency Manager / Coder**
 - Update request with: package name, current version, target version

--- a/agents/workflows/documentation.md
+++ b/agents/workflows/documentation.md
@@ -35,7 +35,7 @@ A documentation gap or improvement need is identified through one of:
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human → Documenter**
 - Doc request with:

--- a/agents/workflows/feature.md
+++ b/agents/workflows/feature.md
@@ -33,7 +33,7 @@ a clear goal statement and any known constraints or requirements.
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human → Planner**
 - Feature request with goal statement, context, and constraints (issue or structured description)
@@ -45,7 +45,7 @@ The orchestrator validates each handoff artifact before dispatching the next rol
 **Architect → Coder**
 - Feasibility assessment per task (comments on task issues)
 - Design decisions and conventions to follow
-- ADR file in `docs/decisions/` (if the feature introduces new patterns)
+- ADR file in `.teamwork/docs/decisions/` (if the feature introduces new patterns)
 
 **Coder → Tester**
 - Open PR with implementation and initial tests

--- a/agents/workflows/hotfix.md
+++ b/agents/workflows/hotfix.md
@@ -32,7 +32,7 @@ or production monitoring with clear evidence that production is impacted right n
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human → Coder**
 - Incident report with: severity (P0/P1), affected systems, observed symptoms

--- a/agents/workflows/refactor.md
+++ b/agents/workflows/refactor.md
@@ -35,7 +35,7 @@ A refactoring need is identified through one of:
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Initiator → Architect**
 - Refactoring request issue or description with:

--- a/agents/workflows/release.md
+++ b/agents/workflows/release.md
@@ -36,7 +36,7 @@ A human decides the codebase is ready for a new release. This may be driven by:
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human → Planner**
 - Release request with:

--- a/agents/workflows/rollback.md
+++ b/agents/workflows/rollback.md
@@ -31,7 +31,7 @@ commit or PR that needs to be reverted and the reason for the rollback.
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human/Tester → Human**
 - Identification of the bad merge: commit SHA or PR number

--- a/agents/workflows/security-response.md
+++ b/agents/workflows/security-response.md
@@ -36,7 +36,7 @@ A security vulnerability is discovered through one of:
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Reporter → Security Auditor**
 - Vulnerability description with reproduction steps or proof of concept

--- a/agents/workflows/spike.md
+++ b/agents/workflows/spike.md
@@ -36,7 +36,7 @@ alone and requires hands-on investigation:
 
 Each step must produce specific artifacts before the next step can begin.
 
-The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `docs/protocols.md`.
+The orchestrator validates each handoff artifact before dispatching the next role. Handoffs are stored in `.teamwork/handoffs/<workflow-id>/` following the format in `.teamwork/docs/protocols.md`.
 
 **Human → Planner**
 - Investigation request with:
@@ -79,7 +79,7 @@ The orchestrator validates each handoff artifact before dispatching the next rol
 ## Notes
 
 - **Output is a document, not code**: The deliverable of a spike is a decision document —
-  typically an ADR filed in `docs/decisions/`. Any proof-of-concept code is throwaway and
+  typically an ADR filed in `.teamwork/docs/decisions/`. Any proof-of-concept code is throwaway and
   must not be merged to production branches. If the spike validates an approach, the actual
   implementation starts fresh through the Feature or Refactoring workflow.
 - **Time-box is mandatory**: Every spike must have a time box defined upfront. Spikes without

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -21,11 +21,27 @@ import (
 // These are overwritten on update (if unchanged by user).
 var FrameworkFiles = []string{
 	"agents/",
-	"docs/",
+	"docs/architecture.md",
+	"docs/conflict-resolution.md",
+	"docs/conventions.md",
+	"docs/cost-policy.md",
+	"docs/glossary.md",
+	"docs/protocols.md",
+	"docs/role-selector.md",
+	"docs/secrets-policy.md",
+	"docs/workflow-selector.md",
 	".github/copilot-instructions.md",
 	"CLAUDE.md",
 	".cursorrules",
 	"Makefile",
+}
+
+// pathRemaps maps source path prefixes to destination prefixes.
+// Files under these source prefixes are written to the remapped destination
+// in target repos, keeping framework files hidden under .teamwork/.
+var pathRemaps = map[string]string{
+	"agents/": ".teamwork/agents/",
+	"docs/":   ".teamwork/docs/",
 }
 
 // StarterTemplates maps relative path to content for files created once on install.
@@ -72,14 +88,15 @@ func Install(dir, owner, repo, ref string) error {
 
 	written := 0
 	for _, f := range files {
-		dst := filepath.Join(dir, f.Path)
+		destPath := remapPath(f.Path)
+		dst := filepath.Join(dir, destPath)
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return fmt.Errorf("creating directory for %s: %w", f.Path, err)
+			return fmt.Errorf("creating directory for %s: %w", destPath, err)
 		}
 		if err := os.WriteFile(dst, f.Data, 0o644); err != nil {
-			return fmt.Errorf("writing %s: %w", f.Path, err)
+			return fmt.Errorf("writing %s: %w", destPath, err)
 		}
-		m.Files[f.Path] = sha256hex(f.Data)
+		m.Files[destPath] = sha256hex(f.Data)
 		written++
 	}
 
@@ -104,14 +121,12 @@ func Install(dir, owner, repo, ref string) error {
 		starterCreated++
 	}
 
-	// Initialize .teamwork/ if it doesn't exist (mirrors init command logic).
+	// Initialize .teamwork/ subdirectories.
 	teamworkDir := filepath.Join(dir, ".teamwork")
-	if _, err := os.Stat(teamworkDir); err != nil {
-		subdirs := []string{"state", "handoffs", "memory", "metrics"}
-		for _, sub := range subdirs {
-			if err := os.MkdirAll(filepath.Join(teamworkDir, sub), 0o755); err != nil {
-				return fmt.Errorf("creating .teamwork/%s: %w", sub, err)
-			}
+	subdirs := []string{"state", "handoffs", "memory", "metrics"}
+	for _, sub := range subdirs {
+		if err := os.MkdirAll(filepath.Join(teamworkDir, sub), 0o755); err != nil {
+			return fmt.Errorf("creating .teamwork/%s: %w", sub, err)
 		}
 	}
 
@@ -158,25 +173,26 @@ func Update(dir, owner, repo, ref string, force bool) error {
 	var skippedPaths []string
 
 	for _, f := range files {
+		destPath := remapPath(f.Path)
 		newHash := sha256hex(f.Data)
-		newManifest.Files[f.Path] = newHash
-		dst := filepath.Join(dir, f.Path)
+		newManifest.Files[destPath] = newHash
+		dst := filepath.Join(dir, destPath)
 
 		existing, err := os.ReadFile(dst)
 		if err != nil {
 			// File doesn't exist locally — write it.
 			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-				return fmt.Errorf("creating directory for %s: %w", f.Path, err)
+				return fmt.Errorf("creating directory for %s: %w", destPath, err)
 			}
 			if err := os.WriteFile(dst, f.Data, 0o644); err != nil {
-				return fmt.Errorf("writing %s: %w", f.Path, err)
+				return fmt.Errorf("writing %s: %w", destPath, err)
 			}
 			updated++
 			continue
 		}
 
 		currentHash := sha256hex(existing)
-		manifestHash := oldManifest.Files[f.Path]
+		manifestHash := oldManifest.Files[destPath]
 
 		if currentHash == newHash {
 			// Already matches new version.
@@ -187,7 +203,7 @@ func Update(dir, owner, repo, ref string, force bool) error {
 		if currentHash == manifestHash || manifestHash == "" {
 			// User hasn't modified it (or untracked) — overwrite.
 			if err := os.WriteFile(dst, f.Data, 0o644); err != nil {
-				return fmt.Errorf("writing %s: %w", f.Path, err)
+				return fmt.Errorf("writing %s: %w", destPath, err)
 			}
 			updated++
 			continue
@@ -196,14 +212,14 @@ func Update(dir, owner, repo, ref string, force bool) error {
 		// User modified the file.
 		if force {
 			if err := os.WriteFile(dst, f.Data, 0o644); err != nil {
-				return fmt.Errorf("writing %s: %w", f.Path, err)
+				return fmt.Errorf("writing %s: %w", destPath, err)
 			}
 			updated++
 			continue
 		}
 
 		skipped++
-		skippedPaths = append(skippedPaths, f.Path)
+		skippedPaths = append(skippedPaths, destPath)
 	}
 
 	if err := writeManifest(dir, newManifest); err != nil {
@@ -336,6 +352,17 @@ func isFrameworkFile(path string) bool {
 		}
 	}
 	return false
+}
+
+// remapPath applies path remapping for target repo layout.
+// Source paths like "agents/roles/coder.md" become ".teamwork/agents/roles/coder.md".
+func remapPath(path string) string {
+	for src, dst := range pathRemaps {
+		if strings.HasPrefix(path, src) {
+			return dst + strings.TrimPrefix(path, src)
+		}
+	}
+	return path
 }
 
 func readManifest(dir string) (*Manifest, error) {

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -121,10 +121,48 @@ func TestIsFrameworkFile_Excluded(t *testing.T) {
 		"CHANGELOG.md",
 		"README.md",
 		".github/workflows/ci.yaml",
+		"docs/cli.md",
+		"docs/state-machines.md",
+		"docs/onboarding.md",
+		"docs/decisions/001-role-based-agent-framework.md",
+		"docs/decisions/README.md",
 	}
 	for _, c := range cases {
 		if isFrameworkFile(c) {
 			t.Errorf("expected %q to NOT be a framework file", c)
+		}
+	}
+}
+
+// -- remapPath --
+
+func TestRemapPath_AgentsRemapped(t *testing.T) {
+	cases := map[string]string{
+		"agents/roles/coder.md":        ".teamwork/agents/roles/coder.md",
+		"agents/workflows/feature.md":  ".teamwork/agents/workflows/feature.md",
+		"agents/README.md":             ".teamwork/agents/README.md",
+		"docs/conventions.md":          ".teamwork/docs/conventions.md",
+		"docs/glossary.md":             ".teamwork/docs/glossary.md",
+	}
+	for input, want := range cases {
+		got := remapPath(input)
+		if got != want {
+			t.Errorf("remapPath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestRemapPath_RootFilesUnchanged(t *testing.T) {
+	cases := []string{
+		"CLAUDE.md",
+		".cursorrules",
+		"Makefile",
+		".github/copilot-instructions.md",
+	}
+	for _, input := range cases {
+		got := remapPath(input)
+		if got != input {
+			t.Errorf("remapPath(%q) = %q, want unchanged", input, got)
 		}
 	}
 }
@@ -161,8 +199,8 @@ func TestWriteReadManifest(t *testing.T) {
 	m := &Manifest{
 		Version: "sha123",
 		Files: map[string]string{
-			"agents/roles/coder.md": "deadbeef",
-			"CLAUDE.md":             "cafebabe",
+			".teamwork/agents/roles/coder.md": "deadbeef",
+			"CLAUDE.md":                       "cafebabe",
 		},
 	}
 	if err := writeManifest(dir, m); err != nil {
@@ -530,8 +568,8 @@ func TestInstall_CleanDir_FrameworkFilesWritten(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"agents/roles/coder.md",
-		"docs/conventions.md",
+		".teamwork/agents/roles/coder.md",
+		".teamwork/docs/conventions.md",
 		"CLAUDE.md",
 		".cursorrules",
 		"Makefile",
@@ -732,14 +770,14 @@ func TestUpdate_NewUpstreamFile_Written(t *testing.T) {
 
 	const newPrefix = "JoshLuedeman-teamwork-def5678def5678/"
 	tb2 := makeTarball(newPrefix, map[string]string{
-		"CLAUDE.md":           "original\n",
-		"docs/new-feature.md": "brand new file\n",
+		"CLAUDE.md":            "original\n",
+		"agents/roles/new.md":  "brand new file\n",
 	})
 	if err := serveAndUpdate(t, dir, tb2, false); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, "docs/new-feature.md")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, ".teamwork/agents/roles/new.md")); err != nil {
 		t.Errorf("new upstream file not written: %v", err)
 	}
 }
@@ -851,8 +889,8 @@ func TestManifest_JSONRoundTrip(t *testing.T) {
 	m := &Manifest{
 		Version: "sha123abc",
 		Files: map[string]string{
-			"CLAUDE.md":           sha256hex([]byte("content")),
-			"agents/roles/coder.md": sha256hex([]byte("coder")),
+			"CLAUDE.md":                        sha256hex([]byte("content")),
+			".teamwork/agents/roles/coder.md":  sha256hex([]byte("coder")),
 		},
 	}
 	data, err := json.MarshalIndent(m, "", "  ")


### PR DESCRIPTION
## Problem
The installer used a broad `docs/` prefix to decide which files to extract from the tarball. This caused CLI-specific files (`docs/cli.md`, `docs/state-machines.md`, `docs/onboarding.md`, `docs/decisions/`) to be installed into target repos where they don't belong. Additionally, `agents/` and `docs/` directories were placed at the repo root, cluttering the project.

## Solution
- **Path remapping**: Framework files now install under `.teamwork/` in target repos (`agents/` → `.teamwork/agents/`, specific docs → `.teamwork/docs/`)
- **Explicit allowlist**: Replaced broad `docs/` prefix with 9 specific framework doc files
- **Updated references**: All AI instruction files and agent role/workflow files now reference `.teamwork/` paths
- Root-level files that must stay at fixed paths (`CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `Makefile`) are unchanged

## Files changed
- `internal/installer/installer.go` — Added `remapPath()`, explicit doc allowlist, fixed subdir creation
- `internal/installer/installer_test.go` — New tests for `remapPath()`, updated expected paths, added exclusion cases
- 3 AI instruction files — Updated path references
- 10 agent role/workflow files — Updated `docs/` references to `.teamwork/docs/`