### PR TITLE
chore(docs): renumber MCP ADR from 006 to 007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`teamwork fail` CLI command** — Mark workflows as failed with required reason (#63)
 - **`teamwork doctor` CLI command** — Environment diagnostics with actionable fix suggestions (#49)
 - **`CONTRIBUTING.md`** — Contribution guide covering setup, standards, and PR process (#56)
-- **ADR-006** — MCP integration strategy design document (#20)
+- **ADR-007** — MCP integration strategy design document (#20)
 - **`teamwork memory` CLI command** — `add`, `search`, `list`, `sync` subcommands for managing structured project memory (#66)
 - **`teamwork metrics` CLI command** — `summary` and `roles` subcommands for workflow analytics (#67)
 - **`teamwork repos` CLI command** — List configured repositories and their status (#73)

--- a/docs/decisions/007-mcp-integration-strategy.md
+++ b/docs/decisions/007-mcp-integration-strategy.md
@@ -1,4 +1,4 @@
-# ADR-006: MCP Integration Strategy
+# ADR-007: MCP Integration Strategy
 
 **Status:** proposed
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,3 +15,4 @@ See [`docs/architecture.md`](../architecture.md) for the ADR template and guidan
 | [003](003-go-orchestration-app.md) | Go Orchestration Application | Accepted | 2026-03-02 |
 | [004](004-validate-command-design.md) | Validate Command Design | Proposed | 2025-07-18 |
 | [005](005-install-update-design.md) | Install and Update Command Design | Proposed | 2025-07-18 |
+| [007](007-mcp-integration-strategy.md) | MCP Integration Strategy | Proposed | 2026-03-03 |


### PR DESCRIPTION
## Task Issue
Prerequisite for Phase 3 milestone issues.

## Description
Renames ADR-006 (MCP Integration Strategy) to ADR-007 to free the ADR-006 number for the Phase 3 GitHub App + Cloudflare Worker design document.

## Changes
- Renamed `docs/decisions/006-mcp-integration-strategy.md` → `007-mcp-integration-strategy.md`
- Updated title inside the ADR from "ADR-006" to "ADR-007"
- Updated CHANGELOG.md reference
- Added ADR-007 entry to `docs/decisions/README.md` index

## Checklist
- [x] Changes are minimal (only what the task requires)
- [x] No secrets or credentials committed
- [x] Documentation updated
- [x] Follows project conventions (docs/conventions.md)