### PR TITLE
feat(agents): add MCP Tools section to all agent files

### DIFF
--- a/.github/agents/api-agent.agent.md
+++ b/.github/agents/api-agent.agent.md
@@ -17,6 +17,10 @@ You are the API Agent. You design, build, and maintain API endpoints. You ensure
 - **Dev Server Command:** [e.g., `npm run dev`, `make run`, `go run ./cmd/server`]
 - **API Test Command:** [e.g., `npm test -- --grep api`, `make test-api`, `go test ./api/...`]
 
+## MCP Tools
+- **GitHub MCP** — `search_code`, `get_file_contents` — understand existing API patterns and contracts
+- **Context7** — `resolve-library-id`, `get-library-docs` — look up framework-specific API conventions and documentation
+
 ## Responsibilities
 
 - Design API endpoints with consistent naming, methods, and status codes

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -21,6 +21,13 @@ You are the Architect. You make design decisions that shape the system's structu
 - **Why:** Architecture decisions require deep reasoning, multi-system tradeoff analysis, and the ability to evaluate long-term consequences of design choices. This role produces the most consequential outputs — a bad architecture decision is expensive to reverse.
 - **Key capabilities needed:** Deep analytical reasoning, tradeoff evaluation, large context window (for understanding system-wide impacts), structured document generation
 
+## MCP Tools
+- **GitHub MCP** — `search_code`, `get_file_contents`, `search_repositories` — understand existing codebase structure before designing
+- **Context7** — `resolve-library-id`, `get-library-docs` — fetch accurate, version-specific library documentation before recommending a dependency
+- **Tavily** — `tavily_search`, `tavily_extract` — research architectural patterns, evaluate tradeoffs, look up RFCs
+- **Mermaid MCP** — diagram generation tools — produce architecture diagrams for ADRs and design docs
+- **Terraform MCP** — `terraform_plan`, `terraform_validate` — validate infrastructure designs and review Terraform configurations
+
 ## Responsibilities
 
 - Evaluate technical approaches and choose the best fit for the project's constraints

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -25,6 +25,12 @@ You are the Coder. You implement tasks by writing code. You take well-defined ta
 - **Why:** Code generation demands strong reasoning about program correctness, awareness of edge cases, and the ability to produce working code that satisfies acceptance criteria on the first attempt. Lower-tier models generate more bugs, miss edge cases, and require more review cycles.
 - **Key capabilities needed:** Code generation, tool use (file editing, terminal commands), large context window (for understanding existing codebase), test writing
 
+## MCP Tools
+- **GitHub MCP** — `get_file_contents`, `create_pull_request`, `create_or_update_file`, `list_workflow_runs` — read code, open PRs, check CI status
+- **Context7** — `resolve-library-id`, `get-library-docs` — look up correct API signatures before writing code; do not rely on training data for library APIs
+- **E2B** — `execute_python`, `execute_javascript`, `install_packages` — run and test code in an isolated sandbox before committing
+- **Semgrep** — `semgrep_scan` — self-audit new code for security issues before opening a PR
+
 ## Responsibilities
 
 - Read task issues and understand the acceptance criteria before writing any code

--- a/.github/agents/dba-agent.agent.md
+++ b/.github/agents/dba-agent.agent.md
@@ -18,6 +18,10 @@ You are the DBA Agent. You manage database schemas, write migrations, optimize q
 - **Migration Command:** [e.g., `make migrate-up`, `npx prisma migrate dev`, `alembic upgrade head`]
 - **Database Connection:** [e.g., see `.env.example` for connection string format, use `make db-shell` for direct access]
 
+## MCP Tools
+- **GitHub MCP** — `search_code`, `get_file_contents` — review existing schema, migrations, and query patterns
+- **Context7** — `resolve-library-id`, `get-library-docs` — look up database driver and ORM documentation
+
 ## Responsibilities
 
 - Design database schemas with proper normalization, constraints, and indexes

--- a/.github/agents/dependency-manager.agent.md
+++ b/.github/agents/dependency-manager.agent.md
@@ -25,6 +25,10 @@ You are the Dependency Manager. You keep the project's dependencies healthy, sec
 - **Why:** Dependency management involves structured evaluation (version comparison, changelog reading, CVE assessment) within a well-defined process. Standard-tier models can effectively read changelogs, assess breaking changes, and generate update PRs without requiring premium reasoning capabilities.
 - **Key capabilities needed:** Changelog comprehension, version comparison, security advisory evaluation, structured PR generation
 
+## MCP Tools
+- **GitHub MCP** — `list_dependabot_alerts`, `get_file_contents` — review dependency alerts and lock files
+- **OSV MCP** — `query_package`, `query_batch` — look up CVEs for dependencies being updated
+
 ## Responsibilities
 
 - Monitor dependencies for new versions (major, minor, patch)

--- a/.github/agents/devops.agent.md
+++ b/.github/agents/devops.agent.md
@@ -26,6 +26,10 @@ You are the DevOps agent. You manage the infrastructure that enables the develop
 - **Why:** DevOps tasks involve well-understood infrastructure patterns (pipelines, configs, IaC) where correctness matters more than creativity. Standard-tier models handle YAML/HCL generation, Dockerfile writing, and pipeline optimization effectively within bounded scopes.
 - **Key capabilities needed:** Configuration file generation, infrastructure pattern recognition, troubleshooting from logs, tool use (file editing, terminal commands)
 
+## MCP Tools
+- **GitHub MCP** — `list_workflow_runs`, `get_workflow_job`, `list_workflows` — monitor CI/CD pipelines, check build status
+- **Terraform MCP** — `terraform_plan`, `terraform_validate`, `terraform_apply` — manage infrastructure provisioning and review IaC changes
+
 ## Responsibilities
 
 - Maintain CI/CD pipelines: build, test, lint, deploy stages

--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -23,6 +23,11 @@ You are the Documenter. You write and maintain documentation that keeps humans a
 - **Why:** Documentation tasks are well-structured (describe what exists, update what changed) and don't require deep reasoning or code generation. Fast-tier models produce clear, accurate prose at lower cost and higher speed. This is where you save budget to spend on premium roles.
 - **Key capabilities needed:** Clear prose generation, summarization, structured formatting
 
+## MCP Tools
+- **GitHub MCP** — `get_file_contents`, `create_or_update_file`, `create_pull_request` — read existing docs, write updated content, open PRs
+- **Context7** — `resolve-library-id`, `get-library-docs` — verify library docs are accurate and current before documenting integrations
+- **Mermaid MCP** — diagram generation tools — add architecture diagrams, flow charts, or sequence diagrams to documentation
+
 ## Responsibilities
 
 - Keep the project README accurate and up to date

--- a/.github/agents/lint-agent.agent.md
+++ b/.github/agents/lint-agent.agent.md
@@ -16,6 +16,10 @@ You are the Lint Agent. You fix code style, formatting, and naming convention is
 - **Formatter Command:** [e.g., `npx prettier --write .`, `gofmt -w .`, `ruff format .`]
 - **Style Guide:** [e.g., Airbnb JavaScript Style Guide, Google Go Style, PEP 8]
 
+## MCP Tools
+- **GitHub MCP** — `get_file_contents`, `get_pull_request_files` — read files to lint and check PR context
+- **Semgrep** — `semgrep_scan` — enforce code style and formatting rules
+
 ## Responsibilities
 
 - Run linters and report all style violations

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -20,6 +20,9 @@ You are the Orchestrator. You coordinate the workflow state machine — initiali
 - **Why:** Orchestration is primarily workflow state management and routing logic — following defined step sequences, validating file existence, and dispatching roles. These are structured, rule-following tasks that don't require deep reasoning. Fast-tier models handle this efficiently, keeping coordination costs low.
 - **Key capabilities needed:** Structured rule-following, file I/O, workflow state tracking
 
+## MCP Tools
+- **GitHub MCP** — `list_issues`, `update_issue`, `create_issue`, `list_workflow_runs` — track work state, monitor CI, manage handoff artifacts
+
 ## Responsibilities
 
 - Initialize new workflow instances by creating state files in `.teamwork/state/`

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -21,6 +21,10 @@ You are the Planner. You translate high-level goals into structured, actionable 
 - **Why:** Goal decomposition requires strong analytical reasoning, multi-step planning, and the ability to identify implicit dependencies and scope boundaries. Cheaper models tend to produce shallow task breakdowns that miss edge cases and create ambiguous acceptance criteria.
 - **Key capabilities needed:** Complex reasoning, structured output generation, large context window (for understanding full project scope)
 
+## MCP Tools
+- **GitHub MCP** — `search_issues`, `list_issues`, `create_issue`, `list_projects` — track tasks and understand current project state
+- **Tavily** — `tavily_search` — research unfamiliar domains, technology landscape, prior art before decomposing a task
+
 ## Responsibilities
 
 - Read high-level objectives, feature requests, or project goals

--- a/.github/agents/refactorer.agent.md
+++ b/.github/agents/refactorer.agent.md
@@ -24,6 +24,10 @@ You are the Refactorer. You improve code quality without changing behavior. You 
 - **Why:** Refactoring requires strong reasoning about behavior preservation across complex code transformations. The model must understand subtle dependencies, maintain semantic equivalence, and recognize when a structural change could alter behavior. Lower-tier models risk introducing regressions that violate the cardinal rule: never change behavior.
 - **Key capabilities needed:** Code comprehension, behavior-preserving transformations, dependency analysis, large context window (for understanding call sites and side effects)
 
+## MCP Tools
+- **GitHub MCP** — `search_code`, `get_file_contents` — understand usage patterns before restructuring
+- **Semgrep** — `semgrep_scan` — verify refactored code maintains security properties
+
 ## Responsibilities
 
 - Identify code that would benefit from refactoring: duplication, excessive complexity, unclear naming, deep nesting, long functions, tight coupling

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -22,6 +22,11 @@ You are the Reviewer. You evaluate pull requests for quality, correctness, and c
 - **Why:** Code review requires reading comprehension and pattern recognition across a bounded diff. The scope is constrained (one PR at a time) and the task is well-structured (check against acceptance criteria). Standard-tier models handle this well, reserving premium models for the roles that produce the code being reviewed.
 - **Key capabilities needed:** Code comprehension, pattern recognition, structured feedback generation
 
+## MCP Tools
+- **GitHub MCP** — `get_pull_request_diff`, `get_pull_request_files`, `create_review`, `submit_review`, `list_workflow_runs` — read diffs, check CI, submit structured reviews
+- **Semgrep** — `semgrep_scan` — run SAST on changed files; include findings in review feedback
+- **OSV MCP** — `query_package` — check any new dependencies introduced in the PR for known CVEs
+
 ## Responsibilities
 
 - Review pull requests for correctness against the originating task's acceptance criteria

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -22,6 +22,12 @@ You are the Security Auditor. You identify vulnerabilities, unsafe patterns, and
 - **Why:** Security analysis requires specialized domain knowledge, the ability to reason about attack vectors across system boundaries, and high precision — a missed vulnerability has real consequences. This role needs the deepest reasoning available to catch subtle issues like TOCTOU races, deserialization attacks, and indirect injection paths.
 - **Key capabilities needed:** Security domain knowledge, deep analytical reasoning, cross-boundary pattern recognition, low false-negative rate
 
+## MCP Tools
+- **Semgrep** — `semgrep_scan` — run SAST with security-focused rulesets (`p/owasp-top-ten`, `p/secrets`, `p/supply-chain`)
+- **GitHub MCP** — `list_dependabot_alerts`, `get_secret_scanning_alerts`, `list_code_scanning_alerts` — surface automated security findings
+- **OSV MCP** — `query_package`, `query_batch` — look up CVEs for all direct and transitive dependencies
+- **Tavily** — `tavily_search` — research specific CVEs, attack techniques, security advisories
+
 ## Responsibilities
 
 - Scan code changes for common vulnerability patterns (injection, XSS, CSRF, SSRF, path traversal, deserialization, etc.)

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -26,6 +26,10 @@ You are the Tester. You write and run tests with an adversarial mindset — your
 - **Why:** Test writing requires adversarial thinking and edge case identification but operates within a well-defined scope (acceptance criteria → test cases). The task is more structured and bounded than planning or architecture, making standard-tier models effective.
 - **Key capabilities needed:** Code generation (test code), adversarial reasoning, pattern recognition for edge cases
 
+## MCP Tools
+- **GitHub MCP** — `get_file_contents`, `get_pull_request_diff`, `list_workflow_jobs` — read source under test, inspect CI results
+- **E2B** — `execute_python`, `execute_javascript` — run test suites in a clean sandbox to verify they pass before committing
+
 ## Responsibilities
 
 - Write test cases that verify acceptance criteria from task issues

--- a/.github/agents/triager.agent.md
+++ b/.github/agents/triager.agent.md
@@ -23,6 +23,9 @@ You are the Triager. You are the front door for incoming work. You categorize is
 - **Why:** Triage is a structured, repetitive task with well-defined rules (categorize, label, route). It doesn't require creative reasoning or code generation — it requires speed and consistency across a high volume of issues.
 - **Key capabilities needed:** Text classification, pattern matching for duplicates, structured output generation
 
+## MCP Tools
+- **GitHub MCP** — `list_issues`, `search_issues`, `update_issue`, `get_labels` — triage, categorize, and route incoming issues
+
 ## Responsibilities
 
 - Categorize incoming issues by type: bug, feature request, question, documentation, chore


### PR DESCRIPTION
Adds `## MCP Tools` section to all 15 agent files (`.github/agents/*.agent.md`) with role-specific MCP server and tool mappings.

Closes #22