### PR TITLE
feat(validate): add MCP config validation checks

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -41,6 +41,7 @@ func Run(dir string) ([]Result, error) {
 	results = append(results, checkStateFiles(twDir)...)
 	results = append(results, checkHandoffFiles(twDir)...)
 	results = append(results, checkMemoryFiles(twDir)...)
+	results = append(results, checkMCPServers(twDir)...)
 
 	return results, nil
 }
@@ -286,6 +287,173 @@ func checkHandoffFiles(twDir string) []Result {
 
 		return nil
 	})
+
+	return results
+}
+
+// knownRoles enumerates the recognized Teamwork role names.
+var knownRoles = map[string]bool{
+	"planner":            true,
+	"architect":          true,
+	"coder":              true,
+	"tester":             true,
+	"reviewer":           true,
+	"security-auditor":   true,
+	"documenter":         true,
+	"orchestrator":       true,
+	"triager":            true,
+	"devops":             true,
+	"dependency-manager": true,
+	"refactorer":         true,
+	"lint-agent":         true,
+	"api-agent":          true,
+	"dba-agent":          true,
+}
+
+// checkMCPServers validates the mcp_servers section of config.yaml, if present.
+func checkMCPServers(twDir string) []Result {
+	var results []Result
+	cfgPath := filepath.Join(twDir, "config.yaml")
+	relPath := ".teamwork/config.yaml"
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		// config.yaml missing is handled by checkConfigExists; skip silently.
+		return results
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		// Invalid YAML is handled by checkConfigExists; skip silently.
+		return results
+	}
+
+	mcpRaw, ok := raw["mcp_servers"]
+	if !ok {
+		// MCP servers section absent — optional, pass silently.
+		return results
+	}
+
+	servers, _ := mcpRaw.(map[string]interface{})
+	if servers == nil {
+		// Present but empty or null — nothing to validate.
+		return results
+	}
+
+	serverCount := 0
+	missingEnvCount := 0
+
+	for name, entry := range servers {
+		srv, _ := entry.(map[string]interface{})
+		if srv == nil {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "mcp_servers",
+				Passed:  false,
+				Message: fmt.Sprintf("mcp_servers.%s: invalid server entry", name),
+			})
+			continue
+		}
+
+		// description required
+		desc, _ := srv["description"].(string)
+		if desc == "" {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "mcp_servers",
+				Passed:  false,
+				Message: fmt.Sprintf("mcp_servers.%s: missing required field 'description'", name),
+			})
+			continue
+		}
+
+		// url XOR command
+		urlVal, _ := srv["url"].(string)
+		cmdVal, _ := srv["command"].(string)
+		hasURL := urlVal != ""
+		hasCmd := cmdVal != ""
+
+		if hasURL && hasCmd {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "mcp_servers",
+				Passed:  false,
+				Message: fmt.Sprintf("mcp_servers.%s: must have either 'url' or 'command', not both", name),
+			})
+			continue
+		}
+		if !hasURL && !hasCmd {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "mcp_servers",
+				Passed:  false,
+				Message: fmt.Sprintf("mcp_servers.%s: must have either 'url' or 'command'", name),
+			})
+			continue
+		}
+
+		// URL format
+		if hasURL && !strings.HasPrefix(urlVal, "http://") && !strings.HasPrefix(urlVal, "https://") {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "mcp_servers",
+				Passed:  false,
+				Message: fmt.Sprintf("mcp_servers.%s: url must start with http:// or https://", name),
+			})
+			continue
+		}
+
+		// roles validation
+		rolesRaw, _ := srv["roles"].([]interface{})
+		invalidRole := false
+		for _, r := range rolesRaw {
+			roleName, _ := r.(string)
+			if !knownRoles[roleName] {
+				results = append(results, Result{
+					Path:    relPath,
+					Check:   "mcp_servers",
+					Passed:  false,
+					Message: fmt.Sprintf("mcp_servers.%s: invalid role %q", name, roleName),
+				})
+				invalidRole = true
+				break
+			}
+		}
+		if invalidRole {
+			continue
+		}
+
+		// env var warnings
+		envVarsRaw, _ := srv["env_vars"].([]interface{})
+		for _, ev := range envVarsRaw {
+			envName, _ := ev.(string)
+			if envName != "" && os.Getenv(envName) == "" {
+				results = append(results, Result{
+					Path:    relPath,
+					Check:   "mcp_servers",
+					Passed:  true,
+					Message: fmt.Sprintf("mcp_servers.%s: WARN env var %s is not set", name, envName),
+				})
+				missingEnvCount++
+			}
+		}
+
+		serverCount++
+	}
+
+	// Summary result when all servers are valid
+	if serverCount > 0 {
+		msg := fmt.Sprintf("mcp_servers: %d servers configured", serverCount)
+		if missingEnvCount > 0 {
+			msg = fmt.Sprintf("mcp_servers: %d servers configured (%d env vars missing)", serverCount, missingEnvCount)
+		}
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "mcp_servers",
+			Passed:  true,
+			Message: msg,
+		})
+	}
 
 	return results
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -352,6 +352,411 @@ func TestRun_InvalidMemoryYAMLFails(t *testing.T) {
 	}
 }
 
+// writeMCPTestConfig writes a config.yaml with MCP content into dir/.teamwork/.
+func writeMCPTestConfig(t *testing.T, dir string, configYAML string) {
+	t.Helper()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(configYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// filterMCPResults returns only results with Check == "mcp_servers".
+func filterMCPResults(results []validate.Result) []validate.Result {
+	var out []validate.Result
+	for _, r := range results {
+		if r.Check == "mcp_servers" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestCheckMCPConfig_NoSection(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if len(mcpResults) != 0 {
+		t.Errorf("expected no MCP results, got %d: %+v", len(mcpResults), mcpResults)
+	}
+}
+
+func TestCheckMCPConfig_EmptySection(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers: {}
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	for _, r := range mcpResults {
+		if !r.Passed {
+			t.Errorf("expected all MCP results to pass, got failure: %s", r.Message)
+		}
+	}
+}
+
+func TestCheckMCPConfig_ValidURL(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  test-server:
+    description: "Test server"
+    url: "https://example.com/mcp"
+    roles: [coder]
+    env_vars: []
+    install: "npm install test"
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if len(mcpResults) == 0 {
+		t.Fatal("expected MCP results, got none")
+	}
+	for _, r := range mcpResults {
+		if !r.Passed {
+			t.Errorf("expected pass, got failure: %s", r.Message)
+		}
+	}
+}
+
+func TestCheckMCPConfig_ValidCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  local-tool:
+    description: "Local tool"
+    command: "npx @modelcontextprotocol/server"
+    roles: [coder]
+    env_vars: []
+    install: "npm install tool"
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if len(mcpResults) == 0 {
+		t.Fatal("expected MCP results, got none")
+	}
+	for _, r := range mcpResults {
+		if !r.Passed {
+			t.Errorf("expected pass, got failure: %s", r.Message)
+		}
+	}
+}
+
+func TestCheckMCPConfig_MissingURLAndCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  broken:
+    description: "No transport"
+    roles: [coder]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) == 0 {
+		t.Error("expected failure for missing url and command")
+	}
+}
+
+func TestCheckMCPConfig_BothURLAndCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  both:
+    description: "Has both"
+    url: "https://example.com/mcp"
+    command: "npx server"
+    roles: [coder]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) == 0 {
+		t.Error("expected failure for having both url and command")
+	}
+}
+
+func TestCheckMCPConfig_InvalidURL(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  bad-url:
+    description: "Bad URL"
+    url: "not-a-url"
+    roles: [coder]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) == 0 {
+		t.Error("expected failure for invalid URL")
+	}
+}
+
+func TestCheckMCPConfig_UnknownRole(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  wizard-server:
+    description: "Unknown role"
+    url: "https://example.com/mcp"
+    roles: [wizard]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) == 0 {
+		t.Error("expected failure for unknown role")
+	}
+	msgs := failedMessages(mcpResults)
+	found := false
+	for _, m := range msgs {
+		if contains(m, "invalid role") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected message mentioning 'invalid role', got: %v", msgs)
+	}
+}
+
+func TestCheckMCPConfig_MissingDescription(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  no-desc:
+    url: "https://example.com/mcp"
+    roles: [coder]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) == 0 {
+		t.Error("expected failure for missing description")
+	}
+}
+
+func TestCheckMCPConfig_MissingEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  env-server:
+    description: "Env test"
+    url: "https://example.com/mcp"
+    roles: [coder]
+    env_vars: [TAVILY_API_KEY]
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	// Should pass (warning, not failure)
+	if countFailed(mcpResults) != 0 {
+		t.Errorf("expected no failures for missing env var (warning only), got: %v", failedMessages(mcpResults))
+	}
+	// Should contain a WARN message
+	foundWarn := false
+	for _, r := range mcpResults {
+		if contains(r.Message, "WARN") && contains(r.Message, "TAVILY_API_KEY") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Error("expected a WARN message mentioning TAVILY_API_KEY")
+	}
+}
+
+func TestCheckMCPConfig_SetEnvVar(t *testing.T) {
+	t.Setenv("TAVILY_API_KEY", "test-value")
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  env-server:
+    description: "Env test"
+    url: "https://example.com/mcp"
+    roles: [coder]
+    env_vars: [TAVILY_API_KEY]
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	for _, r := range mcpResults {
+		if contains(r.Message, "WARN") {
+			t.Errorf("expected no WARN when env var is set, got: %s", r.Message)
+		}
+	}
+}
+
+func TestCheckMCPConfig_MultipleServers(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  server-a:
+    description: "Server A"
+    url: "https://a.example.com/mcp"
+    roles: [coder]
+    env_vars: []
+    install: ""
+  server-b:
+    description: "Server B"
+    url: "https://b.example.com/mcp"
+    roles: [tester]
+    env_vars: []
+    install: ""
+  server-c:
+    description: "Server C"
+    command: "npx server-c"
+    roles: [reviewer]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) != 0 {
+		t.Errorf("expected no failures, got: %v", failedMessages(mcpResults))
+	}
+	// Check for summary mentioning 3 servers
+	foundSummary := false
+	for _, r := range mcpResults {
+		if contains(r.Message, "3 servers configured") {
+			foundSummary = true
+		}
+	}
+	if !foundSummary {
+		var msgs []string
+		for _, r := range mcpResults {
+			msgs = append(msgs, r.Message)
+		}
+		t.Errorf("expected summary mentioning '3 servers configured', got: %v", msgs)
+	}
+}
+
+func TestCheckMCPConfig_MixedValid(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  good-server:
+    description: "Good server"
+    url: "https://example.com/mcp"
+    roles: [coder]
+    env_vars: []
+    install: ""
+  bad-server:
+    url: "https://example.com/mcp"
+    roles: [coder]
+    env_vars: []
+    install: ""
+`)
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mcpResults := filterMCPResults(results)
+	if countFailed(mcpResults) == 0 {
+		t.Error("expected failure for the server missing description")
+	}
+	// The valid server should still produce a pass
+	if countPassed(mcpResults) == 0 {
+		t.Error("expected at least one pass for the valid server")
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
 		func() bool {


### PR DESCRIPTION
Extends `teamwork validate` with MCP config checks: schema validation, URL format, role names, and env var warnings.

## Changes

- **`checkMCPServers`** added to the validation pipeline in `internal/validate/validate.go`
- Schema checks: `description` required, `url` XOR `command`, valid URL prefix, known role names
- Env var warnings (non-fatal, `Passed: true`) for unset environment variables
- 13 new tests covering all validation paths in `internal/validate/validate_test.go`

Closes #26
Closes #28