### PR TITLE
feat(cli): implement teamwork mcp list and config commands

### DIFF
--- a/cmd/teamwork/cmd/mcp.go
+++ b/cmd/teamwork/cmd/mcp.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Manage MCP server configuration",
+	Long:  "List configured MCP servers and generate client configuration.",
+}
+
+func init() {
+	rootCmd.AddCommand(mcpCmd)
+}

--- a/cmd/teamwork/cmd/mcp_config.go
+++ b/cmd/teamwork/cmd/mcp_config.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var mcpConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Generate MCP client configuration",
+	Long:  "Generate paste-ready JSON configuration for MCP clients such as Claude Desktop or VS Code.",
+	RunE:  runMCPConfig,
+}
+
+func init() {
+	mcpConfigCmd.Flags().String("format", "claude-desktop", "Output format: claude-desktop or vscode")
+	mcpConfigCmd.Flags().Bool("only-ready", false, "Exclude servers with missing environment variables")
+	mcpCmd.AddCommand(mcpConfigCmd)
+}
+
+func runMCPConfig(cmd *cobra.Command, _ []string) error {
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		return &ExitError{Code: 1, Message: fmt.Sprintf("failed to load config: %v", err)}
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	onlyReady, _ := cmd.Flags().GetBool("only-ready")
+
+	// Build server entries in sorted order for deterministic output.
+	names := make([]string, 0, len(cfg.MCPServers))
+	for name := range cfg.MCPServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	servers := make(map[string]any)
+	for _, name := range names {
+		srv := cfg.MCPServers[name]
+
+		if onlyReady && !isServerReady(srv) {
+			continue
+		}
+
+		entry := buildServerEntry(srv)
+		servers[name] = entry
+	}
+
+	var wrapper map[string]any
+	switch format {
+	case "vscode":
+		wrapper = map[string]any{"servers": servers}
+	default: // claude-desktop
+		wrapper = map[string]any{"mcpServers": servers}
+	}
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(wrapper)
+}
+
+// isServerReady returns true if all required env vars are set.
+func isServerReady(srv config.MCPServer) bool {
+	for _, v := range srv.EnvVars {
+		if os.Getenv(v) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// buildServerEntry creates the JSON-ready map for an MCP server entry.
+func buildServerEntry(srv config.MCPServer) map[string]any {
+	entry := make(map[string]any)
+
+	if srv.URL != "" {
+		entry["type"] = "http"
+		entry["url"] = srv.URL
+	} else if srv.Command != "" {
+		parts := strings.Fields(srv.Command)
+		entry["type"] = "stdio"
+		entry["command"] = parts[0]
+		if len(parts) > 1 {
+			entry["args"] = parts[1:]
+		}
+	}
+
+	if len(srv.EnvVars) > 0 {
+		envMap := make(map[string]string)
+		for _, v := range srv.EnvVars {
+			envMap[v] = "${" + v + "}"
+		}
+		entry["env"] = envMap
+	}
+
+	return entry
+}

--- a/cmd/teamwork/cmd/mcp_list.go
+++ b/cmd/teamwork/cmd/mcp_list.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var mcpListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured MCP servers",
+	RunE:  runMCPList,
+}
+
+func init() {
+	mcpListCmd.Flags().String("role", "", "Filter servers by role")
+	mcpListCmd.Flags().Bool("json", false, "Output as JSON array")
+	mcpCmd.AddCommand(mcpListCmd)
+}
+
+// mcpServerStatus returns a status string for an MCP server based on its env vars.
+func mcpServerStatus(envVars []string) string {
+	if len(envVars) == 0 {
+		return "✓ ready"
+	}
+	for _, v := range envVars {
+		if os.Getenv(v) == "" {
+			return "✗ missing"
+		}
+	}
+	return "✓ set"
+}
+
+// mcpServerJSON is the JSON representation of an MCP server in list output.
+type mcpServerJSON struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	URL         string   `json:"url,omitempty"`
+	Command     string   `json:"command,omitempty"`
+	Roles       []string `json:"roles"`
+	EnvVars     []string `json:"env_vars"`
+	Status      string   `json:"status"`
+}
+
+func runMCPList(cmd *cobra.Command, _ []string) error {
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		return &ExitError{Code: 1, Message: fmt.Sprintf("failed to load config: %v", err)}
+	}
+
+	if len(cfg.MCPServers) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No MCP servers configured. See docs/mcp.md for setup instructions.")
+		return nil
+	}
+
+	roleFilter, _ := cmd.Flags().GetString("role")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	// Collect and sort server names for deterministic output.
+	names := make([]string, 0, len(cfg.MCPServers))
+	for name := range cfg.MCPServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Apply role filter.
+	var filtered []string
+	for _, name := range names {
+		srv := cfg.MCPServers[name]
+		if roleFilter != "" && !containsRole(srv.Roles, roleFilter) {
+			continue
+		}
+		filtered = append(filtered, name)
+	}
+
+	if jsonOutput {
+		return mcpListJSON(cmd, cfg, filtered)
+	}
+	return mcpListTable(cmd, cfg, filtered)
+}
+
+func mcpListTable(cmd *cobra.Command, cfg *config.Config, names []string) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "%-12s  %-30s  %-18s  %s\n", "SERVER", "ROLES", "ENV VARS", "STATUS")
+	for _, name := range names {
+		srv := cfg.MCPServers[name]
+		roles := strings.Join(srv.Roles, ", ")
+		envVars := strings.Join(srv.EnvVars, ", ")
+		if envVars == "" {
+			envVars = "(none)"
+		}
+		status := mcpServerStatus(srv.EnvVars)
+		fmt.Fprintf(out, "%-12s  %-30s  %-18s  %s\n", name, roles, envVars, status)
+	}
+	return nil
+}
+
+func mcpListJSON(cmd *cobra.Command, cfg *config.Config, names []string) error {
+	servers := make([]mcpServerJSON, 0, len(names))
+	for _, name := range names {
+		srv := cfg.MCPServers[name]
+		servers = append(servers, mcpServerJSON{
+			Name:        name,
+			Description: srv.Description,
+			URL:         srv.URL,
+			Command:     srv.Command,
+			Roles:       srv.Roles,
+			EnvVars:     srv.EnvVars,
+			Status:      mcpServerStatus(srv.EnvVars),
+		})
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(servers)
+}
+
+func containsRole(roles []string, target string) bool {
+	for _, r := range roles {
+		if r == target {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/teamwork/cmd/mcp_test.go
+++ b/cmd/teamwork/cmd/mcp_test.go
@@ -1,0 +1,368 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func writeTestConfig(t *testing.T, dir string, yaml string) {
+	t.Helper()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const threeServerConfig = `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers:
+  github:
+    description: "GitHub operations"
+    url: "https://api.githubcopilot.com/mcp/"
+    roles: [coder, tester]
+    env_vars: [GH_TOKEN]
+    install: "gh extension install github/gh-mcp"
+  semgrep:
+    description: "Security scanning"
+    command: "uvx semgrep-mcp"
+    roles: [security-auditor, coder]
+    env_vars: [SEMGREP_APP_TOKEN]
+    install: "pip install semgrep-mcp"
+  osv:
+    description: "Vulnerability lookup"
+    command: "uvx osv-mcp"
+    roles: [security-auditor]
+    env_vars: []
+    install: "pip install osv-mcp"
+`
+
+// executeMCPCmd runs a subcommand of "teamwork mcp" and captures stdout.
+func executeMCPCmd(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+
+	// Reset flag state to avoid pollution between tests.
+	for _, c := range mcpCmd.Commands() {
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"mcp", "--dir", dir}, args...))
+
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// --- list subcommand tests ---
+
+func TestMCPList_ShowsAllServers(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	out, err := executeMCPCmd(t, dir, "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, name := range []string{"github", "semgrep", "osv"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("expected output to contain %q, got:\n%s", name, out)
+		}
+	}
+}
+
+func TestMCPList_EnvVarSet(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+	t.Setenv("GH_TOKEN", "test-token")
+
+	out, err := executeMCPCmd(t, dir, "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The github line should show "✓ set" since GH_TOKEN is set.
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "github") {
+			if !strings.Contains(line, "✓ set") {
+				t.Errorf("expected github line to contain '✓ set', got: %s", line)
+			}
+			return
+		}
+	}
+	t.Errorf("github server not found in output:\n%s", out)
+}
+
+func TestMCPList_EnvVarMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+	// Do NOT set SEMGREP_APP_TOKEN.
+
+	out, err := executeMCPCmd(t, dir, "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "semgrep") {
+			if !strings.Contains(line, "✗ missing") {
+				t.Errorf("expected semgrep line to contain '✗ missing', got: %s", line)
+			}
+			return
+		}
+	}
+	t.Errorf("semgrep server not found in output:\n%s", out)
+}
+
+func TestMCPList_NoEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	out, err := executeMCPCmd(t, dir, "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "osv") {
+			if !strings.Contains(line, "✓ ready") {
+				t.Errorf("expected osv line to contain '✓ ready', got: %s", line)
+			}
+			return
+		}
+	}
+	t.Errorf("osv server not found in output:\n%s", out)
+}
+
+func TestMCPList_NoMCPSection(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+`)
+
+	out, err := executeMCPCmd(t, dir, "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "No MCP servers configured. See docs/mcp.md for setup instructions."
+	if !strings.Contains(out, expected) {
+		t.Errorf("expected helpful message, got:\n%s", out)
+	}
+}
+
+func TestMCPList_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	// No config.yaml written.
+
+	_, err := executeMCPCmd(t, dir, "list")
+	if err == nil {
+		t.Fatal("expected error for missing config, got nil")
+	}
+
+	var exitErr *ExitError
+	if e, ok := err.(*ExitError); ok {
+		exitErr = e
+	} else {
+		// Cobra may wrap the error message; check for our message.
+		if !strings.Contains(err.Error(), "failed to load config") {
+			t.Fatalf("expected ExitError or config error, got: %v", err)
+		}
+		return
+	}
+	if exitErr.Code != 1 {
+		t.Errorf("expected exit code 1, got %d", exitErr.Code)
+	}
+}
+
+func TestMCPList_RoleFilter(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	out, err := executeMCPCmd(t, dir, "list", "--role", "coder")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// github and semgrep have "coder" in their roles; osv does not.
+	if !strings.Contains(out, "github") {
+		t.Errorf("expected output to contain 'github'")
+	}
+	if !strings.Contains(out, "semgrep") {
+		t.Errorf("expected output to contain 'semgrep'")
+	}
+	if strings.Contains(out, "osv") {
+		t.Errorf("expected output NOT to contain 'osv', got:\n%s", out)
+	}
+}
+
+func TestMCPList_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	out, err := executeMCPCmd(t, dir, "list", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var servers []mcpServerJSON
+	if err := json.Unmarshal([]byte(out), &servers); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+
+	if len(servers) != 3 {
+		t.Errorf("expected 3 servers, got %d", len(servers))
+	}
+}
+
+// --- config subcommand tests ---
+
+func TestMCPConfig_ClaudeDesktopFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	out, err := executeMCPCmd(t, dir, "config")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	servers, ok := result["mcpServers"]
+	if !ok {
+		t.Fatal("expected 'mcpServers' key in output")
+	}
+
+	// github should be http type.
+	var ghEntry map[string]any
+	if err := json.Unmarshal(servers["github"], &ghEntry); err != nil {
+		t.Fatalf("parsing github entry: %v", err)
+	}
+	if ghEntry["type"] != "http" {
+		t.Errorf("expected github type 'http', got %v", ghEntry["type"])
+	}
+	if ghEntry["url"] != "https://api.githubcopilot.com/mcp/" {
+		t.Errorf("expected github url, got %v", ghEntry["url"])
+	}
+
+	// semgrep should be stdio type with command/args.
+	var sgEntry map[string]any
+	if err := json.Unmarshal(servers["semgrep"], &sgEntry); err != nil {
+		t.Fatalf("parsing semgrep entry: %v", err)
+	}
+	if sgEntry["type"] != "stdio" {
+		t.Errorf("expected semgrep type 'stdio', got %v", sgEntry["type"])
+	}
+	if sgEntry["command"] != "uvx" {
+		t.Errorf("expected semgrep command 'uvx', got %v", sgEntry["command"])
+	}
+	args, ok := sgEntry["args"].([]any)
+	if !ok || len(args) != 1 || args[0] != "semgrep-mcp" {
+		t.Errorf("expected semgrep args ['semgrep-mcp'], got %v", sgEntry["args"])
+	}
+}
+
+func TestMCPConfig_VSCodeFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	out, err := executeMCPCmd(t, dir, "config", "--format", "vscode")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	if _, ok := result["servers"]; !ok {
+		t.Fatal("expected 'servers' key in vscode output")
+	}
+	if _, ok := result["mcpServers"]; ok {
+		t.Fatal("unexpected 'mcpServers' key in vscode output")
+	}
+}
+
+func TestMCPConfig_OnlyReady(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, threeServerConfig)
+
+	// Set GH_TOKEN but not SEMGREP_APP_TOKEN.
+	t.Setenv("GH_TOKEN", "test-token")
+
+	out, err := executeMCPCmd(t, dir, "config", "--only-ready")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	servers := result["mcpServers"]
+
+	// github (env set) and osv (no env needed) should be present.
+	if _, ok := servers["github"]; !ok {
+		t.Error("expected github in output (env var is set)")
+	}
+	if _, ok := servers["osv"]; !ok {
+		t.Error("expected osv in output (no env vars needed)")
+	}
+	// semgrep should be excluded (env var missing).
+	if _, ok := servers["semgrep"]; ok {
+		t.Error("expected semgrep to be excluded (env var missing)")
+	}
+}
+
+func TestMCPConfig_EmptyServers(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, `project:
+  name: test
+  repo: test/test
+roles:
+  core: [coder]
+mcp_servers: {}
+`)
+
+	out, err := executeMCPCmd(t, dir, "config")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	servers := result["mcpServers"]
+	if len(servers) != 0 {
+		t.Errorf("expected empty mcpServers, got %d entries", len(servers))
+	}
+}


### PR DESCRIPTION
Adds `teamwork mcp` command group with `list` and `config` subcommands for managing MCP server configuration.

## What's included

### `teamwork mcp list`
- Displays a table of configured MCP servers with roles, env vars, and status
- `--role <name>` flag to filter servers by role
- `--json` flag for machine-readable JSON output
- Status logic: ✓ ready (no env vars needed), ✓ set (all env vars present), ✗ missing (env vars not set)

### `teamwork mcp config`  
- Generates paste-ready JSON config for MCP clients
- `--format claude-desktop` (default): wraps in `{"mcpServers": ...}`
- `--format vscode`: wraps in `{"servers": ...}`
- `--only-ready` flag to exclude servers with missing env vars
- URL servers → `http` type; command servers → `stdio` type with parsed command/args

### Tests
- 12 test cases covering both subcommands (env var status, filtering, JSON output, format variants, edge cases)

Closes #25
Closes #27