### PR TITLE
docs(mcp): add config and docs for 5 custom MCP servers

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -27,6 +27,8 @@ You are the Architect. You make design decisions that shape the system's structu
 - **Tavily** — `tavily_search`, `tavily_extract` — research architectural patterns, evaluate tradeoffs, look up RFCs
 - **Mermaid MCP** — diagram generation tools — produce architecture diagrams for ADRs and design docs
 - **Terraform MCP** — `terraform_plan`, `terraform_validate` — validate infrastructure designs and review Terraform configurations
+- **ADR MCP** — `search_adrs`, `create_adr`, `list_adrs` — search existing decisions, create new ADRs, and manage the decision log
+- **Complexity MCP** — `analyze_complexity`, `get_hotspots` — assess codebase health and identify high-complexity areas during design reviews
 
 ## Responsibilities
 

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -30,6 +30,8 @@ You are the Coder. You implement tasks by writing code. You take well-defined ta
 - **Context7** — `resolve-library-id`, `get-library-docs` — look up correct API signatures before writing code; do not rely on training data for library APIs
 - **E2B** — `execute_python`, `execute_javascript`, `install_packages` — run and test code in an isolated sandbox before committing
 - **Semgrep** — `semgrep_scan` — self-audit new code for security issues before opening a PR
+- **Commits MCP** — `generate_commit_message` — generate conventional commit messages from staged diffs
+- **ADR MCP** — `search_adrs`, `get_adr` — read architecture decisions before implementing to ensure alignment with design choices
 
 ## Responsibilities
 

--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -27,6 +27,7 @@ You are the Documenter. You write and maintain documentation that keeps humans a
 - **GitHub MCP** — `get_file_contents`, `create_or_update_file`, `create_pull_request` — read existing docs, write updated content, open PRs
 - **Context7** — `resolve-library-id`, `get-library-docs` — verify library docs are accurate and current before documenting integrations
 - **Mermaid MCP** — diagram generation tools — add architecture diagrams, flow charts, or sequence diagrams to documentation
+- **Changelog MCP** — `generate_changelog`, `preview_release_notes`, `list_unreleased` — generate changelogs and preview release notes for documentation
 
 ## Responsibilities
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -22,6 +22,9 @@ You are the Orchestrator. You coordinate the workflow state machine — initiali
 
 ## MCP Tools
 - **GitHub MCP** — `list_issues`, `update_issue`, `create_issue`, `list_workflow_runs` — track work state, monitor CI, manage handoff artifacts
+- **Coverage MCP** — `load_coverage_report`, `check_thresholds` — verify coverage meets release readiness criteria before approving handoffs
+- **Commits MCP** — `generate_commit_message`, `validate_commit_message` — generate PR descriptions and validate commit message conventions
+- **Changelog MCP** — `generate_changelog`, `list_unreleased` — produce release notes and track unreleased changes across workflows
 
 ## Responsibilities
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -24,6 +24,7 @@ You are the Planner. You translate high-level goals into structured, actionable 
 ## MCP Tools
 - **GitHub MCP** — `search_issues`, `list_issues`, `create_issue`, `list_projects` — track tasks and understand current project state
 - **Tavily** — `tavily_search` — research unfamiliar domains, technology landscape, prior art before decomposing a task
+- **Changelog MCP** — `list_unreleased`, `suggest_next_version` — review unreleased changes to scope releases and inform planning
 
 ## Responsibilities
 

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -26,6 +26,9 @@ You are the Reviewer. You evaluate pull requests for quality, correctness, and c
 - **GitHub MCP** — `get_pull_request_diff`, `get_pull_request_files`, `create_review`, `submit_review`, `list_workflow_runs` — read diffs, check CI, submit structured reviews
 - **Semgrep** — `semgrep_scan` — run SAST on changed files; include findings in review feedback
 - **OSV MCP** — `query_package` — check any new dependencies introduced in the PR for known CVEs
+- **Coverage MCP** — `load_coverage_report`, `check_thresholds` — enforce coverage quality gates; flag PRs that reduce coverage
+- **Commits MCP** — `validate_commit_message` — verify PR commits follow conventional commit format
+- **Complexity MCP** — `analyze_complexity` — flag functions with high cyclomatic complexity in changed files
 
 ## Responsibilities
 

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -29,6 +29,7 @@ You are the Tester. You write and run tests with an adversarial mindset — your
 ## MCP Tools
 - **GitHub MCP** — `get_file_contents`, `get_pull_request_diff`, `list_workflow_jobs` — read source under test, inspect CI results
 - **E2B** — `execute_python`, `execute_javascript` — run test suites in a clean sandbox to verify they pass before committing
+- **Coverage MCP** — `load_coverage_report`, `check_thresholds` — parse lcov/Istanbul/Go coverage reports and verify coverage meets project thresholds
 
 ## Responsibilities
 

--- a/.teamwork/config.yaml
+++ b/.teamwork/config.yaml
@@ -121,6 +121,41 @@ mcp_servers:
     env_vars: [TF_TOKEN]
     install: "npx -y terraform-mcp-server@latest"
 
+  coverage:
+    description: "Test coverage report analysis — lcov, Istanbul, Go cover.out"
+    command: "uvx teamwork-mcp-coverage"
+    roles: [tester, reviewer, orchestrator]
+    env_vars: []
+    install: "pip install teamwork-mcp-coverage"
+
+  commits:
+    description: "Conventional commit message generation and validation from diffs"
+    command: "uvx teamwork-mcp-commits"
+    roles: [coder, reviewer, orchestrator]
+    env_vars: []
+    install: "pip install teamwork-mcp-commits"
+
+  adr:
+    description: "Architecture Decision Record search, creation, and management"
+    command: "uvx teamwork-mcp-adr"
+    roles: [architect, orchestrator, coder]
+    env_vars: []
+    install: "pip install teamwork-mcp-adr"
+
+  changelog:
+    description: "Changelog generation and release notes using git-cliff"
+    command: "uvx teamwork-mcp-changelog"
+    roles: [documenter, orchestrator, planner]
+    env_vars: []
+    install: "pip install teamwork-mcp-changelog"
+
+  complexity:
+    description: "Code complexity analysis — cyclomatic complexity for 30+ languages"
+    command: "uvx teamwork-mcp-complexity"
+    roles: [reviewer, tester, architect]
+    env_vars: []
+    install: "pip install teamwork-mcp-complexity"
+
 # Multi-repo coordination (hub-spoke model)
 # The repo where teamwork runs is the hub. Spoke repos are listed here.
 # repos:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,19 @@ Teamwork agents become significantly more capable when paired with MCP (Model Co
 
 See **[docs/mcp.md](docs/mcp.md)** for full setup instructions and client configuration.
 
-### Recommended servers
+### Teamwork MCP servers
+
+Five custom MCP servers are included in [`mcp-servers/`](mcp-servers/README.md), purpose-built for Teamwork workflows:
+
+| Server | Install | What it unlocks |
+|--------|---------|-----------------| 
+| [Coverage](mcp-servers/coverage/) | `pip install teamwork-mcp-coverage` | Coverage report analysis (lcov, Istanbul, Go) |
+| [Commits](mcp-servers/commits/) | `pip install teamwork-mcp-commits` | Conventional commit generation and validation |
+| [ADR](mcp-servers/adr/) | `pip install teamwork-mcp-adr` | Architecture Decision Record management |
+| [Changelog](mcp-servers/changelog/) | `pip install teamwork-mcp-changelog` | Changelog and release notes via git-cliff |
+| [Complexity](mcp-servers/complexity/) | `pip install teamwork-mcp-complexity` | Cyclomatic complexity analysis (30+ languages) |
+
+### Recommended third-party servers
 
 | Server | Install | What it unlocks |
 |--------|---------|-----------------| 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -8,14 +8,14 @@ Configure MCP servers in `.teamwork/config.yaml` and agents automatically discov
 
 | Role | Servers |
 |------|---------|
-| Planner | GitHub MCP, Tavily |
-| Architect | GitHub MCP, Context7, Tavily, Mermaid, Terraform |
-| Coder | GitHub MCP, Context7, E2B, Semgrep |
-| Tester | GitHub MCP, E2B |
-| Reviewer | GitHub MCP, Semgrep, OSV |
+| Planner | GitHub MCP, Tavily, Changelog |
+| Architect | GitHub MCP, Context7, Tavily, Mermaid, Terraform, ADR, Complexity |
+| Coder | GitHub MCP, Context7, E2B, Semgrep, Commits, ADR |
+| Tester | GitHub MCP, E2B, Coverage, Complexity |
+| Reviewer | GitHub MCP, Semgrep, OSV, Coverage, Commits, Complexity |
 | Security Auditor | Semgrep, GitHub MCP, OSV, Tavily |
-| Documenter | GitHub MCP, Context7, Mermaid |
-| Orchestrator | GitHub MCP |
+| Documenter | GitHub MCP, Context7, Mermaid, Changelog |
+| Orchestrator | GitHub MCP, Coverage, Commits, ADR, Changelog |
 | Triager | GitHub MCP |
 | DevOps | GitHub MCP, Terraform |
 | Dependency Manager | GitHub MCP, OSV |
@@ -329,6 +329,186 @@ npx -y terraform-mcp-server@latest
 }
 ```
 
+### Coverage MCP (Teamwork)
+
+Test coverage report analysis. Parses lcov, Istanbul JSON, and Go `cover.out` reports to surface coverage gaps to agents.
+
+**Install:**
+
+```bash
+pip install teamwork-mcp-coverage
+```
+
+**Required env vars:** None
+
+**Claude Desktop config:**
+
+```json
+{
+  "coverage": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-coverage"]
+  }
+}
+```
+
+**VS Code config:**
+
+```json
+{
+  "coverage": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-coverage"]
+  }
+}
+```
+
+### Commits MCP (Teamwork)
+
+Conventional commit message generation and validation. Reads git diffs and produces structured, conventional-commit-compliant messages.
+
+**Install:**
+
+```bash
+pip install teamwork-mcp-commits
+```
+
+**Required env vars:** None
+
+**Claude Desktop config:**
+
+```json
+{
+  "commits": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-commits"]
+  }
+}
+```
+
+**VS Code config:**
+
+```json
+{
+  "commits": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-commits"]
+  }
+}
+```
+
+### ADR MCP (Teamwork)
+
+Architecture Decision Record search, creation, and management. Works with MADR-format markdown files in `docs/decisions/`.
+
+**Install:**
+
+```bash
+pip install teamwork-mcp-adr
+```
+
+**Required env vars:** None
+
+**Claude Desktop config:**
+
+```json
+{
+  "adr": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-adr"]
+  }
+}
+```
+
+**VS Code config:**
+
+```json
+{
+  "adr": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-adr"]
+  }
+}
+```
+
+### Changelog MCP (Teamwork)
+
+Changelog generation and release notes using git-cliff. Generates changelogs, previews release notes, lists unreleased commits, and suggests the next semantic version.
+
+**Install:**
+
+```bash
+pip install teamwork-mcp-changelog
+```
+
+**Required env vars:** None
+
+**Claude Desktop config:**
+
+```json
+{
+  "changelog": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-changelog"]
+  }
+}
+```
+
+**VS Code config:**
+
+```json
+{
+  "changelog": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-changelog"]
+  }
+}
+```
+
+### Complexity MCP (Teamwork)
+
+Code complexity analysis using the lizard static analysis library. Computes cyclomatic complexity for 30+ languages.
+
+**Install:**
+
+```bash
+pip install teamwork-mcp-complexity
+```
+
+**Required env vars:** None
+
+**Claude Desktop config:**
+
+```json
+{
+  "complexity": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-complexity"]
+  }
+}
+```
+
+**VS Code config:**
+
+```json
+{
+  "complexity": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["teamwork-mcp-complexity"]
+  }
+}
+```
+
 ## Full Client Configuration
 
 ### Claude Desktop
@@ -377,6 +557,31 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
       "command": "npx",
       "args": ["-y", "terraform-mcp-server@latest"],
       "env": { "TF_TOKEN": "${TF_TOKEN}" }
+    },
+    "coverage": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-coverage"]
+    },
+    "commits": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-commits"]
+    },
+    "adr": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-adr"]
+    },
+    "changelog": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-changelog"]
+    },
+    "complexity": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-complexity"]
     }
   }
 }
@@ -428,6 +633,31 @@ Add to `.vscode/mcp.json` in your project root:
       "command": "npx",
       "args": ["-y", "terraform-mcp-server@latest"],
       "env": { "TF_TOKEN": "${TF_TOKEN}" }
+    },
+    "coverage": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-coverage"]
+    },
+    "commits": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-commits"]
+    },
+    "adr": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-adr"]
+    },
+    "changelog": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-changelog"]
+    },
+    "complexity": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["teamwork-mcp-complexity"]
     }
   }
 }
@@ -456,6 +686,11 @@ Or run `teamwork mcp config --format vscode` to generate this automatically.
 | OSV | Unlimited | — |
 | Mermaid | Unlimited (runs locally) | — |
 | Terraform | Unlimited Registry lookups | HCP features, private registry |
+| Coverage (Teamwork) | Unlimited (runs locally) | — |
+| Commits (Teamwork) | Unlimited (runs locally) | — |
+| ADR (Teamwork) | Unlimited (runs locally) | — |
+| Changelog (Teamwork) | Unlimited (runs locally) | — |
+| Complexity (Teamwork) | Unlimited (runs locally) | — |
 
 ## Future MCP Servers
 

--- a/mcp-servers/README.md
+++ b/mcp-servers/README.md
@@ -1,0 +1,79 @@
+# Teamwork MCP Servers
+
+Custom [Model Context Protocol](https://modelcontextprotocol.io/) servers built specifically for Teamwork agent workflows. Each server exposes focused tools that agents invoke during planning, coding, reviewing, and releasing.
+
+## Servers
+
+| Server | Description | Issue |
+|--------|-------------|-------|
+| [coverage](coverage/) | Test coverage report analysis — lcov, Istanbul, Go `cover.out` | [#33](https://github.com/JoshLuedeman/teamwork/issues/33) |
+| [commits](commits/) | Conventional commit message generation and validation from diffs | [#31](https://github.com/JoshLuedeman/teamwork/issues/31) |
+| [adr](adr/) | Architecture Decision Record search, creation, and management | [#34](https://github.com/JoshLuedeman/teamwork/issues/34) |
+| [changelog](changelog/) | Changelog generation and release notes using git-cliff | [#30](https://github.com/JoshLuedeman/teamwork/issues/30) |
+| [complexity](complexity/) | Code complexity analysis — cyclomatic complexity for 30+ languages | [#32](https://github.com/JoshLuedeman/teamwork/issues/32) |
+
+## Installation
+
+Each server is a standalone Python package. Install whichever servers your workflow needs.
+
+### pip install
+
+```bash
+pip install teamwork-mcp-coverage
+pip install teamwork-mcp-commits
+pip install teamwork-mcp-adr
+pip install teamwork-mcp-changelog
+pip install teamwork-mcp-complexity
+```
+
+### uvx (run without installing)
+
+```bash
+uvx teamwork-mcp-coverage
+uvx teamwork-mcp-commits
+uvx teamwork-mcp-adr
+uvx teamwork-mcp-changelog
+uvx teamwork-mcp-complexity
+```
+
+### Docker
+
+Each server includes a `Dockerfile`. Build and run individually:
+
+```bash
+cd mcp-servers/coverage
+docker build -t teamwork-mcp-coverage .
+docker run --rm teamwork-mcp-coverage
+
+cd mcp-servers/commits
+docker build -t teamwork-mcp-commits .
+docker run --rm teamwork-mcp-commits
+```
+
+## Configuration
+
+After installing, add the servers to `.teamwork/config.yaml` under `mcp_servers:` — they are already pre-configured in this repository. Agents discover them automatically from the config.
+
+See [docs/mcp.md](../docs/mcp.md) for full setup instructions, client configuration (Claude Desktop, VS Code), and role mappings.
+
+## Development
+
+Each server lives in its own directory with:
+
+```
+mcp-servers/<name>/
+├── Dockerfile
+├── pyproject.toml
+├── README.md
+├── src/
+│   └── teamwork_mcp_<name>/
+└── tests/
+```
+
+Run tests for a single server:
+
+```bash
+cd mcp-servers/coverage
+pip install -e ".[dev]"
+pytest
+```


### PR DESCRIPTION
Updates config.yaml, docs/mcp.md, agent files, and README to reference the 5 new Teamwork MCP servers (coverage, commits, adr, changelog, complexity). Adds mcp-servers/README.md as an index.

## Changes

### New file
- **mcp-servers/README.md** — top-level index for the 5 custom MCP servers with install instructions

### Updated files
- **.teamwork/config.yaml** — added 5 new entries to `mcp_servers:` section
- **docs/mcp.md** — added Quick Reference table entries, setup sections, client config, and free tier info for all 5 servers
- **README.md** — added Teamwork MCP servers section with table linking to each server
- **.github/agents/tester.agent.md** — added Coverage MCP
- **.github/agents/reviewer.agent.md** — added Coverage, Commits, and Complexity MCP
- **.github/agents/orchestrator.agent.md** — added Coverage, Commits, and Changelog MCP
- **.github/agents/coder.agent.md** — added Commits and ADR MCP
- **.github/agents/architect.agent.md** — added ADR and Complexity MCP
- **.github/agents/documenter.agent.md** — added Changelog MCP
- **.github/agents/planner.agent.md** — added Changelog MCP

## Testing
- Go tests pass: `go test ./internal/... ./cmd/...`