### PR TITLE
feat: add release awareness to agents and instructions

### DIFF
--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -39,6 +39,8 @@ You are the Documenter. You write and maintain documentation that keeps humans a
 - Write inline documentation (comments, docstrings) for complex or non-obvious code
 - Ensure role files and workflow docs remain accurate as processes evolve
 - Review documentation for clarity, completeness, and correctness
+- Maintain `[Unreleased]` section in CHANGELOG.md — add entries for every merged PR following Keep a Changelog categories (Added, Changed, Deprecated, Removed, Fixed, Security)
+- During releases, finalize CHANGELOG.md by renaming `[Unreleased]` to `[vX.Y.Z] — YYYY-MM-DD` and adding a new empty `[Unreleased]` section
 
 ## Inputs
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -37,6 +37,7 @@ You are the Orchestrator. You coordinate the workflow state machine — initiali
 - Invoke other agents to perform their roles (planner, architect, coder, tester, reviewer, etc.) with full context from previous handoffs
 - Report workflow status when asked
 - Manage workflow lifecycle: active → blocked → completed / failed / cancelled
+- Monitor for release-readiness: when a GitHub milestone is fully closed or CHANGELOG.md `[Unreleased]` has 5+ entries, proactively suggest cutting a release using `docs/releasing.md` and the `/release-workflow` skill
 
 ## Inputs
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -177,3 +177,19 @@ This is a high-priority background task — migrated content means the user had 
 - Prefer reading existing code and tests before writing new code.
 - When in doubt, check the glossary — terms like "handoff," "escalation," and "quality bar" have specific meanings.
 - One real code snippet showing your style beats three paragraphs describing it.
+
+## Release Awareness
+
+Proactively monitor for release-readiness signals and suggest cutting a release when warranted:
+
+- **Milestone closed** — When all issues in a GitHub milestone are closed, suggest running the `/release-workflow` skill.
+- **Unreleased changes accumulate** — When `CHANGELOG.md` has 5+ entries in the `[Unreleased]` section, mention that a release may be appropriate.
+- **Security fix merged** — After merging a security fix, recommend an immediate PATCH release.
+- **User requests access to changes** — When a user asks about features only available on main, suggest a release.
+
+When a release is warranted:
+1. Reference `docs/releasing.md` for the release process
+2. Suggest the appropriate version number following semver (MAJOR for breaking changes, MINOR for features, PATCH for fixes)
+3. Invoke the `/release-workflow` skill for the full multi-role workflow
+
+The `make release VERSION=vX.Y.Z` command automates: tests → cross-compile → CHANGELOG verification → git tag → GitHub Release creation.

--- a/.github/skills/release-workflow/SKILL.md
+++ b/.github/skills/release-workflow/SKILL.md
@@ -115,3 +115,7 @@ The orchestrator validates each handoff artifact before dispatching the next rol
   quality gate fails, the orchestrator keeps the workflow at the current step and notifies
   the responsible role. If a blocker is raised, the orchestrator sets the workflow to
   `blocked` and escalates to the human.
+- **Release process reference**: See `docs/releasing.md` for the mechanical release process,
+  including `make release` automation, CHANGELOG conventions, semver strategy, and dual-repo
+  sync with `gh-teamwork`. This skill defines the multi-role workflow; `docs/releasing.md`
+  defines the technical steps.


### PR DESCRIPTION
Adds release-readiness monitoring to copilot-instructions.md, orchestrator and documenter agents, and the release-workflow skill. Agents now proactively suggest releases when milestones close or unreleased changes accumulate.