### PR TITLE
feat(cli): add teamwork role create command

### DIFF
--- a/cmd/teamwork/cmd/role.go
+++ b/cmd/teamwork/cmd/role.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var roleCmd = &cobra.Command{
+	Use:   "role",
+	Short: "Manage custom agent roles",
+}
+
+func init() {
+	rootCmd.AddCommand(roleCmd)
+}

--- a/cmd/teamwork/cmd/role_create.go
+++ b/cmd/teamwork/cmd/role_create.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+"fmt"
+"os"
+"path/filepath"
+"regexp"
+"strings"
+"text/template"
+
+"github.com/spf13/cobra"
+)
+
+// builtinRoles lists role names reserved for built-in and planned agents.
+var builtinRoles = map[string]bool{
+"planner":            true,
+"architect":          true,
+"coder":              true,
+"tester":             true,
+"reviewer":           true,
+"security-auditor":   true,
+"documenter":         true,
+"orchestrator":       true,
+"triager":            true,
+"devops":             true,
+"dependency-manager": true,
+"refactorer":         true,
+"lint-agent":         true,
+"api-agent":          true,
+"dba-agent":          true,
+"product-owner":      true,
+"qa-lead":            true,
+}
+
+var kebabCaseRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
+
+type roleTemplateData struct {
+Name        string
+Title       string
+Description string
+Tier        string
+}
+
+const roleTemplate = `---
+name: {{.Name}}
+description: "{{.Description}}"
+tools: ["read", "search", "edit"]
+---
+
+# Role: {{.Title}}
+
+## Identity
+
+You are the {{.Title}}. <!-- TODO: Define this role's identity and purpose -->
+
+## Project Knowledge
+<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
+- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
+
+## Model Requirements
+
+- **Tier:** {{.Tier}}
+- **Why:** <!-- TODO: Explain why this tier is appropriate -->
+- **Key capabilities needed:** <!-- TODO: List key capabilities -->
+
+## MCP Tools
+- **GitHub MCP** — ` + "`" + `list_issues` + "`" + `, ` + "`" + `search_code` + "`" + ` — search and track work
+
+## Responsibilities
+
+- <!-- TODO: Define primary responsibilities -->
+
+## Boundaries
+
+### ✅ Always
+- <!-- TODO: Define mandatory behaviors -->
+
+### ⚠️ Ask First
+- <!-- TODO: Define behaviors requiring human approval -->
+
+### 🚫 Never
+- <!-- TODO: Define prohibited behaviors -->
+
+## Quality Bar
+
+A {{.Title}} handoff is complete when:
+- <!-- TODO: Define completion criteria -->
+`
+
+var roleCreateCmd = &cobra.Command{
+Use:   "create <name>",
+Short: "Scaffold a new custom agent role",
+Args:  cobra.ExactArgs(1),
+RunE:  runRoleCreate,
+}
+
+func init() {
+roleCreateCmd.Flags().String("description", "", "Short description for the agent")
+roleCreateCmd.Flags().String("tier", "standard", "Model tier (premium, standard, fast)")
+roleCmd.AddCommand(roleCreateCmd)
+}
+
+// toTitleCase converts a kebab-case string to Title Case.
+// e.g. "data-engineer" → "Data Engineer"
+func toTitleCase(kebab string) string {
+parts := strings.Split(kebab, "-")
+for i, p := range parts {
+if len(p) > 0 {
+parts[i] = strings.ToUpper(p[:1]) + p[1:]
+}
+}
+return strings.Join(parts, " ")
+}
+
+func runRoleCreate(cmd *cobra.Command, args []string) error {
+name := args[0]
+
+// Validate name format.
+if !kebabCaseRe.MatchString(name) {
+return fmt.Errorf("invalid role name %q: must be lowercase kebab-case (letters, numbers, hyphens)", name)
+}
+
+// Check for conflicts with built-in roles.
+if builtinRoles[name] {
+return fmt.Errorf("role name %q conflicts with a built-in role", name)
+}
+
+dir, err := cmd.Flags().GetString("dir")
+if err != nil {
+return err
+}
+
+description, err := cmd.Flags().GetString("description")
+if err != nil {
+return err
+}
+if description == "" {
+description = "A custom agent role"
+}
+
+tier, err := cmd.Flags().GetString("tier")
+if err != nil {
+return err
+}
+switch tier {
+case "premium", "standard", "fast":
+// valid
+default:
+return fmt.Errorf("invalid tier %q: must be premium, standard, or fast", tier)
+}
+// Capitalize tier for display (e.g. "standard" → "Standard").
+tier = strings.ToUpper(tier[:1]) + tier[1:]
+
+// Build file path.
+agentsDir := filepath.Join(dir, ".github", "agents")
+filePath := filepath.Join(agentsDir, name+".agent.md")
+
+// Check the file doesn't already exist.
+if _, err := os.Stat(filePath); err == nil {
+return fmt.Errorf("file already exists: %s", filePath)
+}
+
+// Create agents directory if it doesn't exist.
+if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+return fmt.Errorf("failed to create directory %s: %w", agentsDir, err)
+}
+
+// Render template.
+data := roleTemplateData{
+Name:        name,
+Title:       toTitleCase(name),
+Description: description,
+Tier:        tier,
+}
+
+tmpl, err := template.New("role").Parse(roleTemplate)
+if err != nil {
+return fmt.Errorf("failed to parse template: %w", err)
+}
+
+f, err := os.Create(filePath)
+if err != nil {
+return fmt.Errorf("failed to create file %s: %w", filePath, err)
+}
+defer f.Close()
+
+if err := tmpl.Execute(f, data); err != nil {
+return fmt.Errorf("failed to render template: %w", err)
+}
+
+out := cmd.OutOrStdout()
+fmt.Fprintf(out, "Created custom agent role: %s\n", filePath)
+fmt.Fprintf(out, "\nNext steps:\n")
+fmt.Fprintf(out, "  1. Edit %s to define the role's identity and responsibilities\n", filePath)
+fmt.Fprintf(out, "  2. Replace CUSTOMIZE and TODO placeholders with your project details\n")
+fmt.Fprintf(out, "  3. Run 'teamwork validate' to check your configuration\n")
+
+return nil
+}

--- a/cmd/teamwork/cmd/role_test.go
+++ b/cmd/teamwork/cmd/role_test.go
@@ -1,0 +1,269 @@
+package cmd
+
+import (
+"bytes"
+"os"
+"path/filepath"
+"strings"
+"testing"
+
+"github.com/spf13/pflag"
+)
+
+// executeRoleCmd runs a "role create" command with the given dir and extra args,
+// returning the combined output and any error.
+func executeRoleCmd(t *testing.T, dir string, args ...string) (string, error) {
+t.Helper()
+
+// Reset flag state to avoid pollution between tests.
+roleCreateCmd.Flags().VisitAll(func(f *pflag.Flag) {
+f.Value.Set(f.DefValue)
+f.Changed = false
+})
+
+buf := new(bytes.Buffer)
+rootCmd.SetOut(buf)
+rootCmd.SetErr(buf)
+rootCmd.SetArgs(append([]string{"role", "create", "--dir", dir}, args...))
+
+err := rootCmd.Execute()
+return buf.String(), err
+}
+
+func TestRoleCreate_ValidName(t *testing.T) {
+dir := t.TempDir()
+
+out, err := executeRoleCmd(t, dir, "data-engineer")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+// Verify success message.
+if !strings.Contains(out, "Created custom agent role") {
+t.Errorf("expected success message, got:\n%s", out)
+}
+
+// Verify file was created.
+filePath := filepath.Join(dir, ".github", "agents", "data-engineer.agent.md")
+content, err := os.ReadFile(filePath)
+if err != nil {
+t.Fatalf("expected file to exist at %s: %v", filePath, err)
+}
+
+// Verify template rendering.
+s := string(content)
+if !strings.Contains(s, "name: data-engineer") {
+t.Error("expected file to contain 'name: data-engineer'")
+}
+if !strings.Contains(s, "# Role: Data Engineer") {
+t.Error("expected file to contain title 'Data Engineer'")
+}
+if !strings.Contains(s, "You are the Data Engineer.") {
+t.Error("expected file to contain identity section")
+}
+if !strings.Contains(s, "**Tier:** Standard") {
+t.Error("expected default tier to be Standard")
+}
+if !strings.Contains(s, `description: "A custom agent role"`) {
+t.Error("expected default description")
+}
+}
+
+func TestRoleCreate_BuiltinRejected(t *testing.T) {
+dir := t.TempDir()
+
+for _, name := range []string{"coder", "planner", "security-auditor", "product-owner", "qa-lead"} {
+_, err := executeRoleCmd(t, dir, name)
+if err == nil {
+t.Errorf("expected error for built-in role %q, got nil", name)
+continue
+}
+if !strings.Contains(err.Error(), "conflicts with a built-in role") {
+t.Errorf("expected conflict error for %q, got: %v", name, err)
+}
+}
+}
+
+func TestRoleCreate_InvalidNameRejected(t *testing.T) {
+dir := t.TempDir()
+
+cases := []struct {
+name string
+desc string
+}{
+{"DataEngineer", "uppercase letters"},
+{"trailing-", "trailing hyphen"},
+{"data--engineer", "double hyphen"},
+{"123start", "starts with number"},
+{"data_engineer", "underscore"},
+{"data.engineer", "dot"},
+}
+
+for _, tc := range cases {
+t.Run(tc.desc, func(t *testing.T) {
+_, err := executeRoleCmd(t, dir, tc.name)
+if err == nil {
+t.Fatalf("expected error for name %q (%s), got nil", tc.name, tc.desc)
+}
+if !strings.Contains(err.Error(), "invalid role name") {
+t.Errorf("expected 'invalid role name' error for %q, got: %v", tc.name, err)
+}
+})
+}
+}
+
+func TestRoleCreate_DescriptionFlag(t *testing.T) {
+dir := t.TempDir()
+
+_, err := executeRoleCmd(t, dir, "--description", "Handles data pipelines", "data-engineer")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+filePath := filepath.Join(dir, ".github", "agents", "data-engineer.agent.md")
+content, err := os.ReadFile(filePath)
+if err != nil {
+t.Fatalf("expected file to exist: %v", err)
+}
+
+if !strings.Contains(string(content), `description: "Handles data pipelines"`) {
+t.Errorf("expected description in frontmatter, got:\n%s", string(content))
+}
+}
+
+func TestRoleCreate_TierFlag(t *testing.T) {
+cases := []struct {
+tier     string
+expected string
+}{
+{"premium", "Premium"},
+{"standard", "Standard"},
+{"fast", "Fast"},
+}
+
+for _, tc := range cases {
+t.Run(tc.tier, func(t *testing.T) {
+dir := t.TempDir()
+
+_, err := executeRoleCmd(t, dir, "--tier", tc.tier, "test-role")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+filePath := filepath.Join(dir, ".github", "agents", "test-role.agent.md")
+content, err := os.ReadFile(filePath)
+if err != nil {
+t.Fatalf("expected file to exist: %v", err)
+}
+
+expected := "**Tier:** " + tc.expected
+if !strings.Contains(string(content), expected) {
+t.Errorf("expected %q in content, got:\n%s", expected, string(content))
+}
+})
+}
+}
+
+func TestRoleCreate_InvalidTierRejected(t *testing.T) {
+dir := t.TempDir()
+
+_, err := executeRoleCmd(t, dir, "--tier", "mega", "test-role")
+if err == nil {
+t.Fatal("expected error for invalid tier, got nil")
+}
+if !strings.Contains(err.Error(), "invalid tier") {
+t.Errorf("expected 'invalid tier' error, got: %v", err)
+}
+}
+
+func TestRoleCreate_FileAlreadyExists(t *testing.T) {
+dir := t.TempDir()
+
+// Pre-create the file.
+agentsDir := filepath.Join(dir, ".github", "agents")
+if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+t.Fatal(err)
+}
+if err := os.WriteFile(filepath.Join(agentsDir, "data-engineer.agent.md"), []byte("existing"), 0o644); err != nil {
+t.Fatal(err)
+}
+
+_, err := executeRoleCmd(t, dir, "data-engineer")
+if err == nil {
+t.Fatal("expected error for existing file, got nil")
+}
+if !strings.Contains(err.Error(), "already exists") {
+t.Errorf("expected 'already exists' error, got: %v", err)
+}
+}
+
+func TestRoleCreate_CreatesAgentsDirectory(t *testing.T) {
+dir := t.TempDir()
+
+// Ensure .github/agents/ does not exist yet.
+agentsDir := filepath.Join(dir, ".github", "agents")
+if _, err := os.Stat(agentsDir); err == nil {
+t.Fatal("expected agents dir to not exist before test")
+}
+
+_, err := executeRoleCmd(t, dir, "my-role")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+// Verify directory was created.
+info, err := os.Stat(agentsDir)
+if err != nil {
+t.Fatalf("expected agents dir to be created: %v", err)
+}
+if !info.IsDir() {
+t.Error("expected agents path to be a directory")
+}
+
+// Verify file exists inside.
+if _, err := os.Stat(filepath.Join(agentsDir, "my-role.agent.md")); err != nil {
+t.Errorf("expected role file to exist: %v", err)
+}
+}
+
+func TestRoleCreate_SingleWordName(t *testing.T) {
+dir := t.TempDir()
+
+out, err := executeRoleCmd(t, dir, "analyst")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+if !strings.Contains(out, "Created custom agent role") {
+t.Errorf("expected success message, got:\n%s", out)
+}
+
+filePath := filepath.Join(dir, ".github", "agents", "analyst.agent.md")
+content, err := os.ReadFile(filePath)
+if err != nil {
+t.Fatalf("expected file to exist: %v", err)
+}
+
+if !strings.Contains(string(content), "# Role: Analyst") {
+t.Error("expected title 'Analyst' for single-word name")
+}
+}
+
+func TestRoleCreate_NextStepsOutput(t *testing.T) {
+dir := t.TempDir()
+
+out, err := executeRoleCmd(t, dir, "my-role")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+
+if !strings.Contains(out, "Next steps:") {
+t.Error("expected 'Next steps:' in output")
+}
+if !strings.Contains(out, "CUSTOMIZE") {
+t.Error("expected CUSTOMIZE mention in next steps")
+}
+if !strings.Contains(out, "TODO") {
+t.Error("expected TODO mention in next steps")
+}
+}


### PR DESCRIPTION
Adds `teamwork role create <name>` for scaffolding custom agent roles with all required sections.

## What changed
- **`cmd/teamwork/cmd/role.go`** — Parent `role` command group
- **`cmd/teamwork/cmd/role_create.go`** — `role create <name>` subcommand with name validation, template rendering, and flags (`--description`, `--tier`)
- **`cmd/teamwork/cmd/role_test.go`** — 10 test cases covering valid names, built-in conflicts, invalid formats, flags, file-exists errors, and directory creation

## Validation
- Rejects built-in role names (17 reserved names)
- Validates kebab-case format
- Creates `.github/agents/<name>.agent.md` from template with all required sections
- Supports `--description` and `--tier` flags

Closes #42