### PR TITLE
feat(ci): add GitHub Actions CI template and --ci flag

### DIFF
--- a/.github/workflows/teamwork-ci.yaml.example
+++ b/.github/workflows/teamwork-ci.yaml.example
@@ -1,0 +1,50 @@
+# Teamwork CI — Copy this file to .github/workflows/teamwork-ci.yaml
+# Validates Teamwork framework structure on every push and PR.
+name: Teamwork CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate Teamwork Structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install teamwork CLI
+        run: |
+          # Option 1: Download from GitHub releases
+          curl -sL "https://github.com/JoshLuedeman/teamwork/releases/latest/download/teamwork-linux-amd64" -o /usr/local/bin/teamwork
+          chmod +x /usr/local/bin/teamwork
+
+          # Option 2: Use gh extension (requires gh CLI)
+          # gh extension install JoshLuedeman/gh-teamwork
+          # gh teamwork init
+
+      - name: Validate framework structure
+        run: teamwork validate --ci
+
+      - name: Check agent files exist
+        run: |
+          echo "Checking required agent files..."
+          for role in planner architect coder tester reviewer security-auditor documenter orchestrator; do
+            if [ ! -f ".github/agents/${role}.agent.md" ]; then
+              echo "ERROR: Missing required agent file: .github/agents/${role}.agent.md"
+              exit 1
+            fi
+          done
+          echo "All required agent files present."
+
+      - name: Check skill files exist
+        run: |
+          echo "Checking required skill files..."
+          for skill in feature-workflow bugfix-workflow refactor-workflow hotfix-workflow release-workflow; do
+            if [ ! -f ".github/skills/${skill}/SKILL.md" ]; then
+              echo "WARNING: Missing skill: .github/skills/${skill}/SKILL.md"
+            fi
+          done
+          echo "Skill check complete."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,15 @@ Open a GitHub issue with:
 
 See `docs/secrets-policy.md` for the project's secrets and credentials policy.
 
+## Continuous Integration
+
+A GitHub Actions workflow template is available at `.github/workflows/teamwork-ci.yaml.example`. Copy it to `.github/workflows/teamwork-ci.yaml` to enable automatic Teamwork structure validation on push and PR.
+
+The workflow validates:
+- `.teamwork/` directory structure
+- Required agent and skill files
+- MCP server configuration
+
 ## Code of Conduct
 
 Be respectful and constructive. We follow the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) code of conduct.

--- a/cmd/teamwork/cmd/validate.go
+++ b/cmd/teamwork/cmd/validate.go
@@ -18,6 +18,7 @@ var validateCmd = &cobra.Command{
 func init() {
 	validateCmd.Flags().Bool("json", false, "Output results as JSON array")
 	validateCmd.Flags().Bool("quiet", false, "Suppress passing checks")
+	validateCmd.Flags().Bool("ci", false, "Machine-readable output (PASS/FAIL/WARN per check, no colors)")
 	rootCmd.AddCommand(validateCmd)
 }
 
@@ -28,6 +29,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 	jsonOut, _ := cmd.Flags().GetBool("json")
 	quiet, _ := cmd.Flags().GetBool("quiet")
+	ciOut, _ := cmd.Flags().GetBool("ci")
 
 	results, err := validate.Run(dir)
 	if err != nil {
@@ -44,11 +46,20 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if jsonOut {
+	switch {
+	case jsonOut:
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		_ = enc.Encode(results)
-	} else {
+	case ciOut:
+		for _, r := range results {
+			prefix := "PASS"
+			if !r.Passed {
+				prefix = "FAIL"
+			}
+			fmt.Fprintf(os.Stdout, "%-6s%s: %s\n", prefix, r.Check, r.Message)
+		}
+	default:
 		for _, r := range results {
 			if quiet && r.Passed {
 				continue

--- a/cmd/teamwork/cmd/validate_test.go
+++ b/cmd/teamwork/cmd/validate_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func init() {
+	// When running tests directly (bypassing cobra Execute), persistent flags
+	// from rootCmd are not merged into child commands. Register "dir" locally
+	// on validateCmd so tests can set it without going through Execute().
+	if validateCmd.Flags().Lookup("dir") == nil {
+		validateCmd.Flags().StringP("dir", "d", ".", "Project root directory")
+	}
+}
+
+func setupValidDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "project:\n  name: test\n  repo: owner/repo\nroles:\n  core: [coder]\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = old
+	return string(out)
+}
+
+func TestCIFlagRegistered(t *testing.T) {
+	f := validateCmd.Flags().Lookup("ci")
+	if f == nil {
+		t.Fatal("--ci flag not registered on validate command")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--ci default = %q, want %q", f.DefValue, "false")
+	}
+}
+
+func TestRunValidate_CIOutput_PassingChecks(t *testing.T) {
+	dir := setupValidDir(t)
+	_ = validateCmd.Flags().Set("dir", dir)
+	_ = validateCmd.Flags().Set("ci", "true")
+	_ = validateCmd.Flags().Set("json", "false")
+	_ = validateCmd.Flags().Set("quiet", "false")
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runValidate(validateCmd, nil)
+	})
+
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		t.Fatal("expected CI output lines, got none")
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "PASS") {
+			t.Errorf("expected line to start with PASS, got: %q", line)
+		}
+	}
+	if strings.Contains(output, "\u2713") || strings.Contains(output, "\u2717") {
+		t.Error("CI output should not contain decorative Unicode characters")
+	}
+	if strings.Contains(output, " passed, ") {
+		t.Error("CI output should not contain summary line")
+	}
+}
+
+func TestRunValidate_CIOutput_FailingChecks(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = validateCmd.Flags().Set("dir", dir)
+	_ = validateCmd.Flags().Set("ci", "true")
+	_ = validateCmd.Flags().Set("json", "false")
+	_ = validateCmd.Flags().Set("quiet", "false")
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = runValidate(validateCmd, nil)
+	})
+
+	exitErr, ok := runErr.(*ExitError)
+	if !ok {
+		t.Fatalf("expected *ExitError, got %T: %v", runErr, runErr)
+	}
+	if exitErr.Code != 1 {
+		t.Errorf("exit code = %d, want 1", exitErr.Code)
+	}
+	if !strings.Contains(output, "FAIL") {
+		t.Errorf("expected FAIL in CI output, got:\n%s", output)
+	}
+}
+
+func TestRunValidate_CIOutput_Format(t *testing.T) {
+	dir := setupValidDir(t)
+	_ = validateCmd.Flags().Set("dir", dir)
+	_ = validateCmd.Flags().Set("ci", "true")
+	_ = validateCmd.Flags().Set("json", "false")
+	_ = validateCmd.Flags().Set("quiet", "false")
+
+	output := captureStdout(t, func() {
+		_ = runValidate(validateCmd, nil)
+	})
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) < 2 {
+			t.Errorf("CI output line missing colon separator: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Adds a GitHub Actions CI workflow template and `--ci` flag to `teamwork validate` for machine-readable output.

## Changes

### 1. `.github/workflows/teamwork-ci.yaml.example`
GitHub Actions workflow template that teams can copy and customize. Uses `.example` extension so it doesn't run in this repo. Validates:
- Teamwork framework structure via `teamwork validate --ci`
- Required agent files (planner, architect, coder, tester, reviewer, security-auditor, documenter, orchestrator)
- Required skill files (feature-workflow, bugfix-workflow, refactor-workflow, hotfix-workflow, release-workflow)

### 2. `--ci` flag on `teamwork validate`
Machine-readable output format for CI pipelines:
- One line per check, prefixed with `PASS` or `FAIL`
- No decorative output (no colors, no Unicode symbols, no summary line)
- Exit code 1 if any checks fail

Example output:
```
PASS  exists: .teamwork/config.yaml: exists
PASS  valid_yaml: .teamwork/config.yaml: valid YAML
PASS  required_fields: .teamwork/config.yaml: has required fields
```

### 3. Updated CONTRIBUTING.md
Added "Continuous Integration" section documenting the workflow template.

### 4. Tests
Added tests for the `--ci` flag covering:
- Flag registration
- Passing checks output format
- Failing checks output and exit code
- Output line format validation

Closes #59