### PR TITLE
feat(cli): add interactive setup wizard to teamwork init

### DIFF
--- a/cmd/teamwork/cmd/init.go
+++ b/cmd/teamwork/cmd/init.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/JoshLuedeman/teamwork/internal/config"
 	"github.com/spf13/cobra"
@@ -16,6 +19,7 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.Flags().Bool("non-interactive", false, "Skip interactive wizard even when stdin is a TTY")
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -25,15 +29,28 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	nonInteractive, err := cmd.Flags().GetBool("non-interactive")
+	if err != nil {
+		return err
+	}
+
 	teamworkDir := filepath.Join(dir, ".teamwork")
 
 	if _, err := os.Stat(teamworkDir); err == nil {
-		fmt.Println(".teamwork/ already exists — skipping initialization.")
+		fmt.Println(".teamwork/ already exists \u2014 skipping initialization.")
 		return nil
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("checking .teamwork/: %w", err)
 	}
 
+	cfg := config.Default()
+
+	// Interactive prompts when stdin is a TTY and not explicitly disabled.
+	if !nonInteractive && isInteractive() {
+		cfg = runWizard(cfg, os.Stdin)
+	}
+
+	// Create subdirectories.
 	subdirs := []string{"state", "handoffs", "memory", "metrics"}
 	for _, sub := range subdirs {
 		if err := os.MkdirAll(filepath.Join(teamworkDir, sub), 0o755); err != nil {
@@ -41,11 +58,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	cfg := config.Default()
 	if err := cfg.Save(dir); err != nil {
-		return fmt.Errorf("writing default config: %w", err)
+		return fmt.Errorf("writing config: %w", err)
 	}
 
+	// Create empty memory files.
 	memoryFiles := []string{
 		"patterns.yaml",
 		"antipatterns.yaml",
@@ -61,5 +78,53 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Initialized .teamwork/ directory.")
+	fmt.Printf("  Config: %s\n", filepath.Join(teamworkDir, "config.yaml"))
+	fmt.Printf("  Project: %s (%s)\n", cfg.Project.Name, cfg.Project.Repo)
 	return nil
+}
+
+// isInteractive reports whether stdin is connected to a terminal.
+func isInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// runWizard prompts the user for project settings, falling back to the
+// defaults already present in cfg when the user presses Enter.
+func runWizard(cfg *config.Config, r io.Reader) *config.Config {
+	reader := bufio.NewReader(r)
+
+	fmt.Println("Teamwork Setup Wizard")
+	fmt.Println("Press Enter to accept defaults shown in [brackets].")
+	fmt.Println()
+
+	// Project name.
+	fmt.Printf("Project name [%s]: ", cfg.Project.Name)
+	if name := readLine(reader); name != "" {
+		cfg.Project.Name = name
+	}
+
+	// GitHub repo.
+	fmt.Printf("GitHub repo (owner/repo) [%s]: ", cfg.Project.Repo)
+	if repo := readLine(reader); repo != "" {
+		cfg.Project.Repo = repo
+	}
+
+	// Optional roles.
+	fmt.Print("Enable optional roles? (triager, devops, dependency-manager, refactorer) [y/N]: ")
+	if answer := readLine(reader); strings.HasPrefix(strings.ToLower(answer), "y") {
+		cfg.Roles.Optional = []string{"triager", "devops", "dependency-manager", "refactorer"}
+	}
+
+	fmt.Println()
+	return cfg
+}
+
+// readLine reads a single line from the reader and trims whitespace.
+func readLine(reader *bufio.Reader) string {
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line)
 }

--- a/cmd/teamwork/cmd/init_test.go
+++ b/cmd/teamwork/cmd/init_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JoshLuedeman/teamwork/internal/config"
+)
+
+func TestRunInit_NonInteractive_CreatesDefaultConfig(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Project.Name != "my-project" {
+		t.Errorf("project name = %q, want %q", cfg.Project.Name, "my-project")
+	}
+	if cfg.Project.Repo != "owner/repo" {
+		t.Errorf("project repo = %q, want %q", cfg.Project.Repo, "owner/repo")
+	}
+}
+
+func TestRunInit_NonInteractiveFlag_SkipsWizard(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir, "--non-interactive"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Project.Name != "my-project" {
+		t.Errorf("project name = %q, want %q", cfg.Project.Name, "my-project")
+	}
+}
+
+func TestRunInit_AlreadyExists_Skips(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	cfgPath := filepath.Join(dir, ".teamwork", "config.yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		t.Error("config.yaml should not exist when .teamwork/ was pre-existing")
+	}
+}
+
+func TestRunInit_CreatesSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	expected := []string{"state", "handoffs", "memory", "metrics"}
+	for _, sub := range expected {
+		path := filepath.Join(dir, ".teamwork", sub)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("subdirectory %q not created: %v", sub, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%q exists but is not a directory", sub)
+		}
+	}
+}
+
+func TestRunInit_CreatesMemoryFiles(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	memoryFiles := []string{"patterns.yaml", "antipatterns.yaml", "decisions.yaml", "feedback.yaml", "index.yaml"}
+	for _, name := range memoryFiles {
+		path := filepath.Join(dir, ".teamwork", "memory", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("memory file %q not created: %v", name, err)
+		}
+	}
+}
+
+func TestRunInit_ConfigFileStructure(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".teamwork", "config.yaml"))
+	if err != nil {
+		t.Fatalf("reading config.yaml: %v", err)
+	}
+	content := string(data)
+	for _, key := range []string{"project:", "roles:", "quality_gates:", "memory:"} {
+		if !strings.Contains(content, key) {
+			t.Errorf("config.yaml missing expected key %q", key)
+		}
+	}
+}
+
+func TestRunWizard_AcceptsDefaults(t *testing.T) {
+	input := strings.NewReader("\n\n\n")
+	cfg := config.Default()
+	result := runWizard(cfg, input)
+	if result.Project.Name != "my-project" {
+		t.Errorf("project name = %q, want %q", result.Project.Name, "my-project")
+	}
+	if result.Project.Repo != "owner/repo" {
+		t.Errorf("project repo = %q, want %q", result.Project.Repo, "owner/repo")
+	}
+	if len(result.Roles.Optional) != 0 {
+		t.Errorf("optional roles = %v, want empty", result.Roles.Optional)
+	}
+}
+
+func TestRunWizard_CustomValues(t *testing.T) {
+	input := strings.NewReader("cool-app\njosh/cool-app\ny\n")
+	cfg := config.Default()
+	result := runWizard(cfg, input)
+	if result.Project.Name != "cool-app" {
+		t.Errorf("project name = %q, want %q", result.Project.Name, "cool-app")
+	}
+	if result.Project.Repo != "josh/cool-app" {
+		t.Errorf("project repo = %q, want %q", result.Project.Repo, "josh/cool-app")
+	}
+	expectedRoles := []string{"triager", "devops", "dependency-manager", "refactorer"}
+	if len(result.Roles.Optional) != len(expectedRoles) {
+		t.Fatalf("optional roles count = %d, want %d", len(result.Roles.Optional), len(expectedRoles))
+	}
+	for i, role := range expectedRoles {
+		if result.Roles.Optional[i] != role {
+			t.Errorf("optional role[%d] = %q, want %q", i, result.Roles.Optional[i], role)
+		}
+	}
+}
+
+func TestRunWizard_OptionalRolesDeclined(t *testing.T) {
+	input := strings.NewReader("\n\nN\n")
+	cfg := config.Default()
+	result := runWizard(cfg, input)
+	if len(result.Roles.Optional) != 0 {
+		t.Errorf("optional roles = %v, want empty when declined", result.Roles.Optional)
+	}
+}
+
+func TestRunWizard_PartialCustomValues(t *testing.T) {
+	input := strings.NewReader("my-app\n\nn\n")
+	cfg := config.Default()
+	result := runWizard(cfg, input)
+	if result.Project.Name != "my-app" {
+		t.Errorf("project name = %q, want %q", result.Project.Name, "my-app")
+	}
+	if result.Project.Repo != "owner/repo" {
+		t.Errorf("project repo = %q, want default %q", result.Project.Repo, "owner/repo")
+	}
+}


### PR DESCRIPTION
Enhances `teamwork init` with an interactive setup wizard that prompts users for:

- **Project name** — defaults to `my-project`
- **GitHub repo** (owner/repo) — defaults to `owner/repo`
- **Optional roles** — enables triager, devops, dependency-manager, refactorer

The wizard runs automatically when stdin is a TTY. It is skipped when:
- stdin is piped (non-TTY)
- `--non-interactive` flag is passed

Includes 10 tests covering the init command (subdirectories, memory files, config structure, already-exists skip) and the wizard function (defaults, custom values, partial input, role decline).

Closes #52