### PR TITLE
feat(cli): add teamwork logs command

### DIFF
--- a/cmd/teamwork/cmd/logs.go
+++ b/cmd/teamwork/cmd/logs.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/JoshLuedeman/teamwork/internal/metrics"
+	"github.com/spf13/cobra"
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs [workflow-id]",
+	Short: "View workflow activity logs",
+	Long:  "Read and filter .teamwork/metrics/ JSONL log entries with human-readable formatting.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runLogs,
+}
+
+func init() {
+	logsCmd.Flags().StringP("role", "r", "", "Filter by role (e.g., coder, tester)")
+	logsCmd.Flags().StringP("action", "a", "", "Filter by action (e.g., start, complete, gate_result)")
+	logsCmd.Flags().IntP("tail", "n", 0, "Show only the last N entries")
+	logsCmd.Flags().String("since", "", "Show entries since timestamp (ISO 8601 or duration like '24h', '7d')")
+	rootCmd.AddCommand(logsCmd)
+}
+
+func runLogs(cmd *cobra.Command, args []string) error {
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return err
+	}
+
+	roleFilter, _ := cmd.Flags().GetString("role")
+	actionFilter, _ := cmd.Flags().GetString("action")
+	tailN, _ := cmd.Flags().GetInt("tail")
+	sinceStr, _ := cmd.Flags().GetString("since")
+
+	var sinceTime time.Time
+	if sinceStr != "" {
+		sinceTime, err = parseSince(sinceStr)
+		if err != nil {
+			return fmt.Errorf("invalid --since value %q: %w", sinceStr, err)
+		}
+	}
+
+	metricsDir := filepath.Join(dir, ".teamwork", "metrics")
+
+	var events []metrics.Event
+	if len(args) == 1 {
+		events, err = metrics.Load(dir, args[0])
+		if err != nil {
+			return fmt.Errorf("loading metrics: %w", err)
+		}
+	} else {
+		events, err = loadAllEvents(metricsDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	if events == nil && !dirExists(metricsDir) {
+		fmt.Fprintln(cmd.OutOrStdout(), "No metrics directory found. Run a workflow to generate activity logs.")
+		return nil
+	}
+
+	filtered := filterEvents(events, roleFilter, actionFilter, sinceTime)
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return filtered[i].Timestamp < filtered[j].Timestamp
+	})
+
+	if tailN > 0 && len(filtered) > tailN {
+		filtered = filtered[len(filtered)-tailN:]
+	}
+
+	w := cmd.OutOrStdout()
+	for _, ev := range filtered {
+		ts := formatTimestamp(ev.Timestamp)
+		wf := truncateLog(ev.Workflow, 24)
+		fmt.Fprintf(w, "%s  %-24s  %-12s  %-10s  %s\n", ts, wf, ev.Action, ev.Role, ev.Detail)
+	}
+
+	return nil
+}
+
+func loadAllEvents(metricsDir string) ([]metrics.Event, error) {
+	entries, err := os.ReadDir(metricsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading metrics directory: %w", err)
+	}
+
+	var all []metrics.Event
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		evs, err := loadEventsFromFile(filepath.Join(metricsDir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, evs...)
+	}
+	return all, nil
+}
+
+func loadEventsFromFile(path string) ([]metrics.Event, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open metrics file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var events []metrics.Event
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var ev metrics.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			return nil, fmt.Errorf("unmarshal event in %s: %w", path, err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read metrics file %s: %w", path, err)
+	}
+	return events, nil
+}
+
+func filterEvents(events []metrics.Event, role, action string, since time.Time) []metrics.Event {
+	if role == "" && action == "" && since.IsZero() {
+		return events
+	}
+
+	var result []metrics.Event
+	for _, ev := range events {
+		if role != "" && ev.Role != role {
+			continue
+		}
+		if action != "" && ev.Action != action {
+			continue
+		}
+		if !since.IsZero() {
+			evTime, err := time.Parse(time.RFC3339, ev.Timestamp)
+			if err != nil {
+				continue
+			}
+			if evTime.Before(since) {
+				continue
+			}
+		}
+		result = append(result, ev)
+	}
+	return result
+}
+
+var durationRegexp = regexp.MustCompile(`^(\d+)([hd])$`)
+
+func parseSince(s string) (time.Time, error) {
+	if m := durationRegexp.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		switch m[2] {
+		case "h":
+			return time.Now().UTC().Add(-time.Duration(n) * time.Hour), nil
+		case "d":
+			return time.Now().UTC().Add(-time.Duration(n) * 24 * time.Hour), nil
+		}
+	}
+
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("expected ISO 8601 date (e.g., 2026-03-01) or relative duration (e.g., 24h, 7d)")
+}
+
+func formatTimestamp(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	return t.Format("2006-01-02 15:04:05")
+}
+
+func truncateLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 3 {
+		return s[:n]
+	}
+	return s[:n-3] + "..."
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/cmd/teamwork/cmd/logs_test.go
+++ b/cmd/teamwork/cmd/logs_test.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JoshLuedeman/teamwork/internal/metrics"
+)
+
+func writeTestEvents(t *testing.T, dir, workflowID string, events []metrics.Event) {
+	t.Helper()
+	for i := range events {
+		if events[i].Workflow == "" {
+			events[i].Workflow = workflowID
+		}
+	}
+	safe := strings.ReplaceAll(workflowID, "/", "__")
+	metricsDir := filepath.Join(dir, ".teamwork", "metrics")
+	if err := os.MkdirAll(metricsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(metricsDir, safe+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	for _, ev := range events {
+		data, err := json.Marshal(ev)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Write(data)
+		f.Write([]byte("\n"))
+	}
+}
+
+func executeLogsCmd(t *testing.T, args ...string) string {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	logsCmd.Flags().Set("role", "")
+	logsCmd.Flags().Set("action", "")
+	logsCmd.Flags().Set("tail", "0")
+	logsCmd.Flags().Set("since", "")
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v\noutput: %s", err, buf.String())
+	}
+	return buf.String()
+}
+
+func TestLogs_NoMetricsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	output := executeLogsCmd(t, "logs", "--dir", dir)
+	if !strings.Contains(output, "No metrics directory found") {
+		t.Errorf("expected helpful message about missing directory, got: %q", output)
+	}
+}
+
+func TestLogs_EmptyMetricsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	metricsDir := filepath.Join(dir, ".teamwork", "metrics")
+	if err := os.MkdirAll(metricsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	output := executeLogsCmd(t, "logs", "--dir", dir)
+	if strings.TrimSpace(output) != "" {
+		t.Errorf("expected empty output, got: %q", output)
+	}
+}
+
+func TestLogs_ParseAndDisplayEvents(t *testing.T) {
+	dir := t.TempDir()
+	events := []metrics.Event{
+		{Timestamp: "2026-03-08T10:30:15Z", Action: "start", Role: "planner", Step: 2, Detail: "Decompose goal"},
+		{Timestamp: "2026-03-08T10:31:42Z", Action: "complete", Role: "planner", Step: 2, Detail: "Step 2 done (87s)", DurationSec: 87},
+	}
+	writeTestEvents(t, dir, "feature/add-oauth", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir)
+	if !strings.Contains(output, "2026-03-08 10:30:15") {
+		t.Errorf("expected formatted timestamp, got: %q", output)
+	}
+	if !strings.Contains(output, "feature/add-oauth") {
+		t.Errorf("expected workflow ID, got: %q", output)
+	}
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 output lines, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "start") {
+		t.Errorf("first line should be start event, got: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "complete") {
+		t.Errorf("second line should be complete event, got: %q", lines[1])
+	}
+}
+
+func TestLogs_RoleFilter(t *testing.T) {
+	dir := t.TempDir()
+	events := []metrics.Event{
+		{Timestamp: "2026-03-08T10:30:15Z", Action: "start", Role: "planner", Step: 1, Detail: "Planning"},
+		{Timestamp: "2026-03-08T10:31:42Z", Action: "start", Role: "coder", Step: 2, Detail: "Coding"},
+		{Timestamp: "2026-03-08T10:32:00Z", Action: "start", Role: "tester", Step: 3, Detail: "Testing"},
+	}
+	writeTestEvents(t, dir, "test-wf", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir, "--role", "coder")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line with role filter, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "coder") {
+		t.Errorf("expected coder entry, got: %q", lines[0])
+	}
+}
+
+func TestLogs_ActionFilter(t *testing.T) {
+	dir := t.TempDir()
+	events := []metrics.Event{
+		{Timestamp: "2026-03-08T10:30:15Z", Action: "start", Role: "planner", Step: 1, Detail: "Starting"},
+		{Timestamp: "2026-03-08T10:31:42Z", Action: "complete", Role: "planner", Step: 1, Detail: "Done"},
+		{Timestamp: "2026-03-08T10:32:00Z", Action: "fail", Role: "coder", Step: 2, Detail: "Failed"},
+	}
+	writeTestEvents(t, dir, "test-wf", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir, "--action", "complete")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line with action filter, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "complete") {
+		t.Errorf("expected complete entry, got: %q", lines[0])
+	}
+}
+
+func TestLogs_TailLimit(t *testing.T) {
+	dir := t.TempDir()
+	events := []metrics.Event{
+		{Timestamp: "2026-03-08T10:30:00Z", Action: "start", Role: "planner", Step: 1, Detail: "First"},
+		{Timestamp: "2026-03-08T10:31:00Z", Action: "start", Role: "coder", Step: 2, Detail: "Second"},
+		{Timestamp: "2026-03-08T10:32:00Z", Action: "start", Role: "tester", Step: 3, Detail: "Third"},
+		{Timestamp: "2026-03-08T10:33:00Z", Action: "start", Role: "reviewer", Step: 4, Detail: "Fourth"},
+		{Timestamp: "2026-03-08T10:34:00Z", Action: "complete", Role: "reviewer", Step: 4, Detail: "Fifth"},
+	}
+	writeTestEvents(t, dir, "test-wf", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir, "--tail", "2")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines with --tail 2, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "Fourth") {
+		t.Errorf("first tail line should be Fourth, got: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "Fifth") {
+		t.Errorf("second tail line should be Fifth, got: %q", lines[1])
+	}
+}
+
+func TestLogs_SinceDurationFilter(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	oldTime := now.Add(-48 * time.Hour).Format(time.RFC3339)
+	recentTime := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	events := []metrics.Event{
+		{Timestamp: oldTime, Action: "start", Role: "planner", Step: 1, Detail: "Old event"},
+		{Timestamp: recentTime, Action: "start", Role: "coder", Step: 2, Detail: "Recent event"},
+	}
+	writeTestEvents(t, dir, "test-wf", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir, "--since", "24h")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line with --since 24h, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "Recent event") {
+		t.Errorf("expected recent event, got: %q", lines[0])
+	}
+}
+
+func TestLogs_WorkflowIDFilter(t *testing.T) {
+	dir := t.TempDir()
+	eventsA := []metrics.Event{
+		{Timestamp: "2026-03-08T10:30:00Z", Action: "start", Role: "planner", Step: 1, Detail: "Workflow A"},
+	}
+	eventsB := []metrics.Event{
+		{Timestamp: "2026-03-08T10:31:00Z", Action: "start", Role: "coder", Step: 1, Detail: "Workflow B"},
+	}
+	writeTestEvents(t, dir, "workflow-a", eventsA)
+	writeTestEvents(t, dir, "workflow-b", eventsB)
+	output := executeLogsCmd(t, "logs", "workflow-a", "--dir", dir)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line for specific workflow, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "Workflow A") {
+		t.Errorf("expected Workflow A entry, got: %q", lines[0])
+	}
+}
+
+func TestLogs_OutputFormat(t *testing.T) {
+	dir := t.TempDir()
+	events := []metrics.Event{
+		{Timestamp: "2026-03-08T10:30:15Z", Action: "start", Role: "planner", Step: 2, Detail: "Step 2: Decompose goal into tasks"},
+	}
+	writeTestEvents(t, dir, "feature/add-oauth", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir)
+	expected := "2026-03-08 10:30:15  feature/add-oauth         start         planner     Step 2: Decompose goal into tasks"
+	line := strings.TrimSpace(output)
+	if line != expected {
+		t.Errorf("output format mismatch:\nwant: %q\ngot:  %q", expected, line)
+	}
+}
+
+func TestLogs_CombinedFilters(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	recentTime := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	oldTime := now.Add(-48 * time.Hour).Format(time.RFC3339)
+	events := []metrics.Event{
+		{Timestamp: oldTime, Action: "start", Role: "coder", Step: 1, Detail: "Old coder start"},
+		{Timestamp: recentTime, Action: "start", Role: "coder", Step: 2, Detail: "Recent coder start"},
+		{Timestamp: recentTime, Action: "complete", Role: "coder", Step: 2, Detail: "Recent coder complete"},
+		{Timestamp: recentTime, Action: "start", Role: "tester", Step: 3, Detail: "Recent tester start"},
+	}
+	writeTestEvents(t, dir, "test-wf", events)
+	output := executeLogsCmd(t, "logs", "--dir", dir, "--role", "coder", "--action", "start", "--since", "24h")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line with combined filters, got %d: %q", len(lines), output)
+	}
+	if !strings.Contains(lines[0], "Recent coder start") {
+		t.Errorf("expected recent coder start, got: %q", lines[0])
+	}
+}
+
+func TestParseSince_Durations(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{"1h"},
+		{"24h"},
+		{"7d"},
+		{"30d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := parseSince(tt.input)
+			if err != nil {
+				t.Fatalf("parseSince(%q) returned error: %v", tt.input, err)
+			}
+			if result.IsZero() {
+				t.Fatalf("parseSince(%q) returned zero time", tt.input)
+			}
+			if result.After(time.Now().UTC()) {
+				t.Errorf("parseSince(%q) returned future time", tt.input)
+			}
+		})
+	}
+}
+
+func TestParseSince_ISODates(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{"2026-03-01"},
+		{"2026-03-01T10:00:00Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := parseSince(tt.input)
+			if err != nil {
+				t.Fatalf("parseSince(%q) returned error: %v", tt.input, err)
+			}
+			if result.IsZero() {
+				t.Fatalf("parseSince(%q) returned zero time", tt.input)
+			}
+		})
+	}
+}
+
+func TestParseSince_Invalid(t *testing.T) {
+	_, err := parseSince("not-a-date")
+	if err == nil {
+		t.Error("expected error for invalid since value")
+	}
+}


### PR DESCRIPTION
Adds `teamwork logs [workflow-id]` for reading, filtering, and formatting workflow activity logs from .teamwork/metrics/ JSONL files.

## What it does

- `teamwork logs` — Show all log entries across all workflows, newest last
- `teamwork logs <workflow-id>` — Show entries for a specific workflow
- `teamwork logs --role coder` — Filter to coder entries only
- `teamwork logs --action complete` — Filter by action type
- `teamwork logs --tail 20` — Last 20 entries
- `teamwork logs --since 24h` — Entries from the last 24 hours
- `teamwork logs --since 2026-03-01` — Entries since a specific date
- Filters can be combined

## Output format

```
2026-03-08 10:30:15  feature/add-oauth         start         planner     Step 2: Decompose goal into tasks
2026-03-08 10:31:42  feature/add-oauth         complete      planner     Step 2 completed (87s)
```

## Tests

13 tests covering: missing directory, empty directory, event parsing, role filter, action filter, tail limit, since duration, workflow ID filter, output format, combined filters, parseSince with durations/ISO dates/invalid input.

Closes #51