### PR TITLE
feat(cli): add --dry-run flag to teamwork start

### DIFF
--- a/cmd/teamwork/cmd/start.go
+++ b/cmd/teamwork/cmd/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/JoshLuedeman/teamwork/internal/config"
 	"github.com/JoshLuedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,7 @@ var startCmd = &cobra.Command{
 
 func init() {
 	startCmd.Flags().IntP("issue", "i", 0, "GitHub issue number to link")
+	startCmd.Flags().Bool("dry-run", false, "Preview workflow steps without creating state files")
 	rootCmd.AddCommand(startCmd)
 }
 
@@ -40,6 +42,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		return runDryRun(cmd, dir, wfType, goal)
+	}
+
 	issue, err := cmd.Flags().GetInt("issue")
 	if err != nil {
 		return err
@@ -55,15 +66,93 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Started workflow %s\n", wf.ID)
-	fmt.Printf("  Type:   %s\n", wf.Type)
-	fmt.Printf("  Goal:   %s\n", goal)
-	fmt.Printf("  Status: %s\n", wf.Status)
+	fmt.Fprintf(cmd.OutOrStdout(), "Started workflow %s\n", wf.ID)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Type:   %s\n", wf.Type)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Goal:   %s\n", goal)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Status: %s\n", wf.Status)
 	if issue > 0 {
-		fmt.Printf("  Issue:  #%d\n", issue)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Issue:  #%d\n", issue)
 	}
 
 	return nil
+}
+
+// runDryRun previews the workflow steps without creating state files.
+func runDryRun(cmd *cobra.Command, dir, wfType, goal string) error {
+	steps, err := workflow.PreviewSteps(wfType)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "\nWorkflow: %s\n", wfType)
+	fmt.Fprintf(out, "Goal: %s\n", goal)
+	fmt.Fprintf(out, "Steps:\n")
+
+	var skipped []string
+	agentSteps := 0
+
+	for _, s := range steps {
+		if cfg.ShouldSkipStep(wfType, s.Role) {
+			skipped = append(skipped, s.Role)
+			fmt.Fprintf(out, "  %d. [%-17s] <- SKIPPED (configured in skip_steps)\n",
+				s.Number, titleCase(s.Role))
+			continue
+		}
+
+		tier := workflow.RoleTier(s.Role)
+		if tier != "" {
+			fmt.Fprintf(out, "  %d. [%-17s] %-40s (%s)\n",
+				s.Number, titleCase(s.Role), s.Action, tier)
+			agentSteps++
+		} else {
+			fmt.Fprintf(out, "  %d. [%-17s] %s\n",
+				s.Number, titleCase(s.Role), s.Action)
+		}
+	}
+
+	// Quality gates.
+	var gates []string
+	if cfg.QualityGates.HandoffComplete {
+		gates = append(gates, "handoff_complete")
+	}
+	if cfg.QualityGates.TestsPass {
+		gates = append(gates, "tests_pass")
+	}
+	if cfg.QualityGates.LintPass {
+		gates = append(gates, "lint_pass")
+	}
+	if len(gates) > 0 {
+		fmt.Fprintf(out, "\nQuality gates: %s\n", strings.Join(gates, ", "))
+	}
+
+	// Skipped steps.
+	if len(skipped) > 0 {
+		fmt.Fprintf(out, "Skipped steps: %s\n", strings.Join(skipped, ", "))
+	} else {
+		fmt.Fprintf(out, "Skipped steps: none\n")
+	}
+
+	fmt.Fprintf(out, "Total agent steps: %d\n", agentSteps)
+
+	return nil
+}
+
+// titleCase converts a kebab-case role name to Title Case for display.
+// e.g. "security-auditor" -> "Security Auditor"
+func titleCase(role string) string {
+	parts := strings.Split(role, "-")
+	for i, p := range parts {
+		if len(p) > 0 {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 func isKnownType(t string) bool {

--- a/cmd/teamwork/cmd/start_test.go
+++ b/cmd/teamwork/cmd/start_test.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// resetStartFlags resets the start command flags between tests to avoid
+// pollution from previous test runs.
+func resetStartFlags(t *testing.T) {
+	t.Helper()
+	startCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+}
+
+// executeStartCmd runs "teamwork start" with the given args and captures stdout.
+func executeStartCmd(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	resetStartFlags(t)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"start", "--dir", dir}, args...))
+
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// minimalConfig is the smallest valid config for dry-run tests.
+const minimalConfig = `project:
+  name: test
+  repo: test/test
+roles:
+  core: [planner, architect, coder, tester, reviewer, security-auditor, documenter]
+quality_gates:
+  handoff_complete: true
+  tests_pass: true
+  lint_pass: true
+`
+
+// skipStepsConfig has skip_steps configured for documentation and spike.
+const skipStepsConfig = `project:
+  name: test
+  repo: test/test
+roles:
+  core: [planner, architect, coder, tester, reviewer, security-auditor, documenter]
+workflows:
+  skip_steps:
+    documentation: [security-auditor]
+    spike: [tester, security-auditor]
+quality_gates:
+  handoff_complete: true
+  tests_pass: true
+  lint_pass: true
+`
+
+func TestDryRun_NoStateFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, minimalConfig)
+
+	stateDir := filepath.Join(dir, ".teamwork", "state")
+
+	out, err := executeStartCmd(t, dir, "feature", "Add OAuth", "--dry-run")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	// Verify no state directory was created.
+	if _, statErr := os.Stat(stateDir); statErr == nil {
+		entries, _ := os.ReadDir(stateDir)
+		t.Errorf("expected no state files, but state dir exists with %d entries", len(entries))
+	}
+}
+
+func TestDryRun_FeatureWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, minimalConfig)
+
+	out, err := executeStartCmd(t, dir, "feature", "Add OAuth", "--dry-run")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	// Check header.
+	if !strings.Contains(out, "Workflow: feature") {
+		t.Errorf("expected 'Workflow: feature' in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Goal: Add OAuth") {
+		t.Errorf("expected 'Goal: Add OAuth' in output:\n%s", out)
+	}
+
+	// Check all feature step roles are present.
+	for _, want := range []string{
+		"Human",
+		"Planner",
+		"Architect",
+		"Coder",
+		"Tester",
+		"Security Auditor",
+		"Reviewer",
+		"Documenter",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected role %q in output:\n%s", want, out)
+		}
+	}
+
+	// Check model tiers are shown.
+	if !strings.Contains(out, "(premium)") {
+		t.Errorf("expected '(premium)' tier in output:\n%s", out)
+	}
+	if !strings.Contains(out, "(standard)") {
+		t.Errorf("expected '(standard)' tier in output:\n%s", out)
+	}
+	if !strings.Contains(out, "(fast)") {
+		t.Errorf("expected '(fast)' tier in output:\n%s", out)
+	}
+
+	// Check quality gates.
+	if !strings.Contains(out, "Quality gates: handoff_complete, tests_pass, lint_pass") {
+		t.Errorf("expected quality gates line in output:\n%s", out)
+	}
+
+	// No skipped steps for feature with minimal config.
+	if !strings.Contains(out, "Skipped steps: none") {
+		t.Errorf("expected 'Skipped steps: none' in output:\n%s", out)
+	}
+
+	// Total agent steps: 7 (9 steps minus 2 human steps).
+	if !strings.Contains(out, "Total agent steps: 7") {
+		t.Errorf("expected 'Total agent steps: 7' in output:\n%s", out)
+	}
+}
+
+func TestDryRun_DocumentationWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, minimalConfig)
+
+	out, err := executeStartCmd(t, dir, "documentation", "Update API docs", "--dry-run")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	if !strings.Contains(out, "Workflow: documentation") {
+		t.Errorf("expected 'Workflow: documentation' in output:\n%s", out)
+	}
+
+	// Documentation has 5 steps: human, documenter, documenter, reviewer, human.
+	if !strings.Contains(out, "Documenter") {
+		t.Errorf("expected 'Documenter' in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Reviewer") {
+		t.Errorf("expected 'Reviewer' in output:\n%s", out)
+	}
+
+	// 3 agent steps (2 documenter + 1 reviewer).
+	if !strings.Contains(out, "Total agent steps: 3") {
+		t.Errorf("expected 'Total agent steps: 3' in output:\n%s", out)
+	}
+}
+
+func TestDryRun_SkipSteps(t *testing.T) {
+	// Use a config that skips security-auditor for feature workflows.
+	skipFeatureConfig := `project:
+  name: test
+  repo: test/test
+roles:
+  core: [planner, architect, coder, tester, reviewer, security-auditor, documenter]
+workflows:
+  skip_steps:
+    feature: [security-auditor]
+quality_gates:
+  handoff_complete: true
+  tests_pass: true
+  lint_pass: true
+`
+	dir := t.TempDir()
+	writeTestConfig(t, dir, skipFeatureConfig)
+
+	out, err := executeStartCmd(t, dir, "feature", "Add OAuth", "--dry-run")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	if !strings.Contains(out, "SKIPPED") {
+		t.Errorf("expected 'SKIPPED' marker in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Skipped steps: security-auditor") {
+		t.Errorf("expected 'Skipped steps: security-auditor' in output:\n%s", out)
+	}
+	// Total agent steps should be 6 (7 minus the skipped security-auditor).
+	if !strings.Contains(out, "Total agent steps: 6") {
+		t.Errorf("expected 'Total agent steps: 6' in output:\n%s", out)
+	}
+}
+
+func TestDryRun_UnknownWorkflowType(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, minimalConfig)
+
+	_, err := executeStartCmd(t, dir, "nonexistent", "some goal", "--dry-run")
+	if err == nil {
+		t.Fatal("expected error for unknown workflow type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown workflow type") {
+		t.Errorf("expected 'unknown workflow type' error, got: %v", err)
+	}
+}
+
+func TestStart_NormalStartStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, minimalConfig)
+
+	// Normal start (without --dry-run) should create state files.
+	out, err := executeStartCmd(t, dir, "feature", "Add OAuth")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	if !strings.Contains(out, "Started workflow") {
+		t.Errorf("expected 'Started workflow' in output:\n%s", out)
+	}
+
+	// State directory should now exist.
+	stateDir := filepath.Join(dir, ".teamwork", "state")
+	if _, statErr := os.Stat(stateDir); os.IsNotExist(statErr) {
+		t.Error("expected state directory to exist after normal start")
+	}
+}

--- a/internal/workflow/preview.go
+++ b/internal/workflow/preview.go
@@ -1,0 +1,36 @@
+package workflow
+
+import "fmt"
+
+// roleTier maps agent roles to their model tier (premium, standard, fast).
+// Human steps have no tier entry.
+var roleTier = map[string]string{
+	"planner":          "premium",
+	"architect":        "premium",
+	"coder":            "premium",
+	"security-auditor": "premium",
+	"tester":           "standard",
+	"reviewer":         "standard",
+	"documenter":       "fast",
+	"orchestrator":     "fast",
+}
+
+// RoleTier returns the model tier for the given role, or an empty string
+// if the role has no tier (e.g., "human").
+func RoleTier(role string) string {
+	return roleTier[role]
+}
+
+// PreviewSteps returns the step definitions for a workflow type without
+// creating any state files. It is used by --dry-run to show what a workflow
+// would look like before starting it.
+func PreviewSteps(workflowType string) ([]StepInfo, error) {
+	def, ok := definitions[workflowType]
+	if !ok {
+		return nil, fmt.Errorf("workflow: unknown type %q", workflowType)
+	}
+	// Return a copy so callers cannot mutate the shared definitions.
+	steps := make([]StepInfo, len(def.Steps))
+	copy(steps, def.Steps)
+	return steps, nil
+}


### PR DESCRIPTION
Adds `teamwork start <type> <goal> --dry-run` to preview workflow steps, roles, model tiers, and skip conditions without creating state files.

## Changes

- **`cmd/teamwork/cmd/start.go`**: Added `--dry-run` flag and `runDryRun()` function that previews workflow steps without creating state files. Also switched `fmt.Printf` to `fmt.Fprintf(cmd.OutOrStdout(), ...)` for testability.
- **`internal/workflow/preview.go`**: New file with `PreviewSteps()` (returns step definitions without creating state) and `RoleTier()` (maps roles to model tiers: premium/standard/fast).
- **`cmd/teamwork/cmd/start_test.go`**: 6 tests covering dry-run output format, no-state-files guarantee, documentation workflow, skip_steps, unknown workflow error, and normal start regression.

## Example Output

```
$ teamwork start feature "Add OAuth" --dry-run

Workflow: feature
Goal: Add OAuth
Steps:
  1. [Human            ] Create feature request
  2. [Planner          ] Decompose goal into tasks              (premium)
  3. [Architect        ] Review feasibility, design             (premium)
  4. [Coder            ] Implement and open PR                  (premium)
  5. [Tester           ] Validate acceptance criteria           (standard)
  6. [Security Auditor ] Scan for vulnerabilities               (premium)
  7. [Reviewer         ] Review for quality                     (standard)
  8. [Human            ] Approve and merge PR
  9. [Documenter       ] Update docs and changelog              (fast)

Quality gates: handoff_complete, tests_pass, lint_pass
Skipped steps: none
Total agent steps: 7
```

Closes #50