### PR TITLE
fix: use lowercase Go module path

### DIFF
--- a/cmd/teamwork/cmd/approve.go
+++ b/cmd/teamwork/cmd/approve.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/block.go
+++ b/cmd/teamwork/cmd/block.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/cancel.go
+++ b/cmd/teamwork/cmd/cancel.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/complete.go
+++ b/cmd/teamwork/cmd/complete.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/dashboard.go
+++ b/cmd/teamwork/cmd/dashboard.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/JoshLuedeman/teamwork/internal/tui"
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/tui"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/doctor.go
+++ b/cmd/teamwork/cmd/doctor.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/JoshLuedeman/teamwork/internal/validate"
+	"github.com/joshluedeman/teamwork/internal/validate"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/fail.go
+++ b/cmd/teamwork/cmd/fail.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/history.go
+++ b/cmd/teamwork/cmd/history.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/init.go
+++ b/cmd/teamwork/cmd/init.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/init_test.go
+++ b/cmd/teamwork/cmd/init_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/config"
 )
 
 func TestRunInit_NonInteractive_CreatesDefaultConfig(t *testing.T) {

--- a/cmd/teamwork/cmd/install.go
+++ b/cmd/teamwork/cmd/install.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/installer"
+	"github.com/joshluedeman/teamwork/internal/installer"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +23,7 @@ If the framework is already installed, use 'teamwork update' instead.`,
 
 func init() {
 	rootCmd.AddCommand(installCmd)
-	installCmd.Flags().String("source", "JoshLuedeman/teamwork", "Source repository (owner/repo)")
+	installCmd.Flags().String("source", "joshluedeman/teamwork", "Source repository (owner/repo)")
 	installCmd.Flags().String("ref", "main", "Git ref to install from (branch, tag, or SHA)")
 	installCmd.Flags().Bool("force", false, "Overwrite existing installation")
 }

--- a/cmd/teamwork/cmd/logs.go
+++ b/cmd/teamwork/cmd/logs.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/JoshLuedeman/teamwork/internal/metrics"
+	"github.com/joshluedeman/teamwork/internal/metrics"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/logs_test.go
+++ b/cmd/teamwork/cmd/logs_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/JoshLuedeman/teamwork/internal/metrics"
+	"github.com/joshluedeman/teamwork/internal/metrics"
 )
 
 func writeTestEvents(t *testing.T, dir, workflowID string, events []metrics.Event) {

--- a/cmd/teamwork/cmd/mcp_config.go
+++ b/cmd/teamwork/cmd/mcp_config.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/mcp_list.go
+++ b/cmd/teamwork/cmd/mcp_list.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/memory.go
+++ b/cmd/teamwork/cmd/memory.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
-	"github.com/JoshLuedeman/teamwork/internal/memory"
+	"github.com/joshluedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/memory"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/metrics.go
+++ b/cmd/teamwork/cmd/metrics.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/JoshLuedeman/teamwork/internal/metrics"
+	"github.com/joshluedeman/teamwork/internal/metrics"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/next.go
+++ b/cmd/teamwork/cmd/next.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/repos.go
+++ b/cmd/teamwork/cmd/repos.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/start.go
+++ b/cmd/teamwork/cmd/start.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/status.go
+++ b/cmd/teamwork/cmd/status.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/cmd/update.go
+++ b/cmd/teamwork/cmd/update.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
-	gh "github.com/JoshLuedeman/teamwork/internal/github"
-	"github.com/JoshLuedeman/teamwork/internal/installer"
+	"github.com/joshluedeman/teamwork/internal/config"
+	gh "github.com/joshluedeman/teamwork/internal/github"
+	"github.com/joshluedeman/teamwork/internal/installer"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +25,7 @@ Use --create-issue=false to disable this behavior.`,
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
-	updateCmd.Flags().String("source", "JoshLuedeman/teamwork", "Source repository (owner/repo)")
+	updateCmd.Flags().String("source", "joshluedeman/teamwork", "Source repository (owner/repo)")
 	updateCmd.Flags().String("ref", "main", "Git ref to update to (branch, tag, or SHA)")
 	updateCmd.Flags().Bool("force", false, "Overwrite user-modified files without warning")
 	updateCmd.Flags().Bool("create-issue", true, "Create a GitHub issue assigned to Copilot for setup when placeholders are detected")

--- a/cmd/teamwork/cmd/update_test.go
+++ b/cmd/teamwork/cmd/update_test.go
@@ -39,12 +39,12 @@ func TestBuildSetupIssueBody_SingleFile(t *testing.T) {
 }
 
 func TestParseUpdateSource_Valid(t *testing.T) {
-	owner, repo, err := parseUpdateSource("JoshLuedeman/teamwork")
+	owner, repo, err := parseUpdateSource("joshluedeman/teamwork")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if owner != "JoshLuedeman" || repo != "teamwork" {
-		t.Errorf("got owner=%q repo=%q, want JoshLuedeman/teamwork", owner, repo)
+	if owner != "joshluedeman" || repo != "teamwork" {
+		t.Errorf("got owner=%q repo=%q, want joshluedeman/teamwork", owner, repo)
 	}
 }
 

--- a/cmd/teamwork/cmd/validate.go
+++ b/cmd/teamwork/cmd/validate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/JoshLuedeman/teamwork/internal/validate"
+	"github.com/joshluedeman/teamwork/internal/validate"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teamwork/main.go
+++ b/cmd/teamwork/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/JoshLuedeman/teamwork/cmd/teamwork/cmd"
+	"github.com/joshluedeman/teamwork/cmd/teamwork/cmd"
 )
 
 // version is set at build time via ldflags:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/JoshLuedeman/teamwork
+module github.com/joshluedeman/teamwork
 
 go 1.24.0
 
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -25,7 +26,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/config"
 )
 
 // Client communicates with GitHub via the gh CLI.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -9,8 +9,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/JoshLuedeman/teamwork/internal/state"
-	"github.com/JoshLuedeman/teamwork/internal/workflow"
+	"github.com/joshluedeman/teamwork/internal/state"
+	"github.com/joshluedeman/teamwork/internal/workflow"
 )
 
 // Styles used throughout the dashboard.

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/JoshLuedeman/teamwork/internal/validate"
+	"github.com/joshluedeman/teamwork/internal/validate"
 )
 
 func writeFile(t *testing.T, dir, rel, content string) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -9,10 +9,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/JoshLuedeman/teamwork/internal/config"
-	"github.com/JoshLuedeman/teamwork/internal/handoff"
-	"github.com/JoshLuedeman/teamwork/internal/metrics"
-	"github.com/JoshLuedeman/teamwork/internal/state"
+	"github.com/joshluedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/handoff"
+	"github.com/joshluedeman/teamwork/internal/metrics"
+	"github.com/joshluedeman/teamwork/internal/state"
 )
 
 // Engine manages workflow execution by coordinating state, handoffs, and metrics.


### PR DESCRIPTION
## Problem

\\go install github.com/joshluedeman/teamwork/cmd/teamwork@latest\\ fails with a 404 from sum.golang.org because Go module paths are **case-sensitive**.

The module was declared as \\github.com/JoshLuedeman/teamwork\\ (mixed case) in go.mod, but users naturally type the lowercase GitHub URL. The Go module proxy treats these as different modules, causing the install to fail with:

\\\
reading https://sum.golang.org/lookup/github.com/joshluedeman/teamwork@v1.2.0: 404 Not Found
fatal: could not read Username for 'https://github.com': terminal prompts disabled
\\\

## Fix

- Changed module path to \\github.com/joshluedeman/teamwork\\ (all lowercase)
- Updated all import statements across 30 files
- Updated \\--source\\ flag defaults in install/update commands
- Ran \\go mod tidy\\ to regenerate go.sum

## Testing

- All tests pass (2 pre-existing failures in installer tests are unrelated to this change)
- Verified \\go build ./...\\ succeeds with new module path

## Notes

- GitHub usernames are case-insensitive for URLs, so lowercase works everywhere
- This is the Go ecosystem convention (lowercase module paths)