### PR TITLE
fix(workflow): enforce quality gates during handoff advancement

### DIFF
--- a/internal/handoff/handoff.go
+++ b/internal/handoff/handoff.go
@@ -17,17 +17,18 @@ import (
 
 // Artifact represents a handoff between two roles in a workflow step.
 type Artifact struct {
-	WorkflowID string
-	Step       int
-	Role       string
-	NextRole   string
-	Date       string
-	Summary    string
-	Artifacts  []string // Files created/modified
-	Context    string   // Context for next role
-	Criteria   []CriterionStatus
-	Questions  []string
-	GatePassed bool
+	WorkflowID  string
+	Step        int
+	Role        string
+	NextRole    string
+	Date        string
+	Summary     string
+	Artifacts   []string // Files created/modified
+	Context     string   // Context for next role
+	Criteria    []CriterionStatus
+	Questions   []string
+	GatePassed  bool
+	GateResults map[string]bool // gate name → pass/fail (e.g. "tests_pass" → true)
 }
 
 // CriterionStatus tracks whether an acceptance criterion has been met.

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -280,6 +280,11 @@ func (e *Engine) Handoff(workflowID string, artifact *handoff.Artifact) error {
 		return fmt.Errorf("workflow: invalid handoff: %s", strings.Join(errs, "; "))
 	}
 
+	// Enforce quality gates from config.
+	if err := e.enforceQualityGates(workflowID, artifact); err != nil {
+		return err
+	}
+
 	ws, err := state.Load(e.Dir, workflowID)
 	if err != nil {
 		return fmt.Errorf("workflow: load state: %w", err)
@@ -338,6 +343,42 @@ func (e *Engine) Handoff(workflowID string, artifact *handoff.Artifact) error {
 	// Log start of the next step.
 	if err := metrics.LogStart(e.Dir, workflowID, ws.CurrentStep, ws.CurrentRole, nextAction); err != nil {
 		return fmt.Errorf("workflow: log next start: %w", err)
+	}
+
+	return nil
+}
+
+// enforceQualityGates checks each configured quality gate against the
+// artifact's GateResults and logs the outcome via metrics.LogGate. It returns
+// an error describing the first gate that has not passed, or nil if all
+// required gates are satisfied.
+func (e *Engine) enforceQualityGates(workflowID string, artifact *handoff.Artifact) error {
+	gates := e.Config.QualityGates
+
+	type gate struct {
+		name    string
+		enabled bool
+	}
+
+	checks := []gate{
+		{"tests_pass", gates.TestsPass},
+		{"lint_pass", gates.LintPass},
+	}
+
+	for _, g := range checks {
+		if !g.enabled {
+			continue
+		}
+		passed, reported := artifact.GateResults[g.name]
+		if reported && passed {
+			_ = metrics.LogGate(e.Dir, workflowID, artifact.Step, artifact.Role, g.name, "passed")
+			continue
+		}
+		_ = metrics.LogGate(e.Dir, workflowID, artifact.Step, artifact.Role, g.name, "failed")
+		if !reported {
+			return fmt.Errorf("workflow: quality gate %q required but not reported in handoff", g.name)
+		}
+		return fmt.Errorf("workflow: quality gate %q failed", g.name)
 	}
 
 	return nil

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,6 +111,10 @@ func TestHandoffRecordsNonZeroDuration(t *testing.T) {
 		Date:       "2025-01-01T00:00:00Z",
 		Summary:    "Implemented feature",
 		Context:    "Ready for testing",
+		GateResults: map[string]bool{
+			"tests_pass": true,
+			"lint_pass":  true,
+		},
 	}
 
 	if err := eng.Handoff("feature/1-test", artifact); err != nil {
@@ -212,5 +217,153 @@ func TestSummarizeAggregatesRealDurations(t *testing.T) {
 	}
 	if s.StepCount != 3 {
 		t.Errorf("StepCount = %d, want 3", s.StepCount)
+	}
+}
+
+// setupEngine creates a temp directory with the required .teamwork subdirectories,
+// an active workflow state file, and returns an Engine ready for testing.
+func setupEngine(t *testing.T, gates config.QualityGatesConfig) (*Engine, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, sub := range []string{"state/feature", "handoffs", "metrics"} {
+		if err := os.MkdirAll(filepath.Join(dir, ".teamwork", sub), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	ws := state.New("feature/1-test", "feature", "Test goal")
+	ws.CurrentStep = 4
+	ws.CurrentRole = "coder"
+	ws.Steps = []state.StepRecord{
+		{Step: 4, Role: "coder", Action: "Implement and open PR", Started: "2025-01-01T00:00:00Z"},
+	}
+	if err := ws.Save(dir); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.QualityGates = gates
+
+	return &Engine{Dir: dir, Config: cfg}, dir
+}
+
+// validArtifact returns a minimal valid handoff artifact for testing.
+func validArtifact(gateResults map[string]bool) *handoff.Artifact {
+	return &handoff.Artifact{
+		WorkflowID:  "feature/1-test",
+		Step:        4,
+		Role:        "coder",
+		NextRole:    "tester",
+		Date:        "2025-01-01T00:00:00Z",
+		Summary:     "Implemented feature",
+		Context:     "Ready for testing",
+		GateResults: gateResults,
+	}
+}
+
+func TestHandoff_QualityGates(t *testing.T) {
+	tests := []struct {
+		name        string
+		gates       config.QualityGatesConfig
+		gateResults map[string]bool
+		wantErr     string // substring expected in error; empty means no error
+	}{
+		{
+			name: "all gates pass",
+			gates: config.QualityGatesConfig{
+				TestsPass: true,
+				LintPass:  true,
+			},
+			gateResults: map[string]bool{
+				"tests_pass": true,
+				"lint_pass":  true,
+			},
+			wantErr: "",
+		},
+		{
+			name: "tests_pass gate fails",
+			gates: config.QualityGatesConfig{
+				TestsPass: true,
+				LintPass:  false,
+			},
+			gateResults: map[string]bool{
+				"tests_pass": false,
+			},
+			wantErr: `quality gate "tests_pass" failed`,
+		},
+		{
+			name: "lint_pass gate fails",
+			gates: config.QualityGatesConfig{
+				TestsPass: false,
+				LintPass:  true,
+			},
+			gateResults: map[string]bool{
+				"lint_pass": false,
+			},
+			wantErr: `quality gate "lint_pass" failed`,
+		},
+		{
+			name: "tests_pass gate not reported",
+			gates: config.QualityGatesConfig{
+				TestsPass: true,
+				LintPass:  false,
+			},
+			gateResults: map[string]bool{},
+			wantErr:     `quality gate "tests_pass" required but not reported`,
+		},
+		{
+			name: "gates disabled allows handoff",
+			gates: config.QualityGatesConfig{
+				TestsPass: false,
+				LintPass:  false,
+			},
+			gateResults: nil,
+			wantErr:     "",
+		},
+		{
+			name: "only tests_pass enabled and passes",
+			gates: config.QualityGatesConfig{
+				TestsPass: true,
+				LintPass:  false,
+			},
+			gateResults: map[string]bool{
+				"tests_pass": true,
+			},
+			wantErr: "",
+		},
+		{
+			name: "only lint_pass enabled and passes",
+			gates: config.QualityGatesConfig{
+				TestsPass: false,
+				LintPass:  true,
+			},
+			gateResults: map[string]bool{
+				"lint_pass": true,
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eng, _ := setupEngine(t, tt.gates)
+			artifact := validArtifact(tt.gateResults)
+
+			err := eng.Handoff("feature/1-test", artifact)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Handoff() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Handoff() expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Handoff() error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Add quality gate enforcement to `Engine.Handoff()` so that configured gates (`tests_pass`, `lint_pass`) are checked before a handoff is accepted.

### Changes

- **`internal/handoff/handoff.go`**: Added `GateResults map[string]bool` field to `Artifact` so callers can report gate outcomes
- **`internal/workflow/engine.go`**: Added `enforceQualityGates()` helper called from `Handoff()` — checks each enabled gate from config, logs results via `metrics.LogGate()`, and returns a descriptive error if a required gate failed or was not reported
- **`internal/workflow/engine_test.go`**: Added 7 table-driven test cases covering all gate pass/fail/disabled combinations

### Test coverage

| Scenario | Expected |
|----------|----------|
| All gates pass | Handoff accepted |
| `tests_pass` gate fails | Error: gate failed |
| `lint_pass` gate fails | Error: gate failed |
| Gate required but not reported | Error: not reported |
| All gates disabled | Handoff accepted |
| Only `tests_pass` enabled, passes | Handoff accepted |
| Only `lint_pass` enabled, passes | Handoff accepted |

Fixes #138