### PR TITLE
fix(installer): only install go.instructions.md for Go projects

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -40,6 +40,13 @@ var StarterTemplates = map[string]string{
 		"The format is based on [Keep a Changelog](https://keepachangelog.com/).\n",
 }
 
+// languageInstructionFiles maps instruction file paths to the marker files
+// that indicate the language is used in the project. If none of the markers
+// exist in the target directory, the instruction file is skipped.
+var languageInstructionFiles = map[string][]string{
+	".github/instructions/go.instructions.md": {"go.mod", "go.sum"},
+}
+
 // File represents a single file extracted from the tarball.
 type File struct {
 	Path string
@@ -68,6 +75,8 @@ func Install(dir, owner, repo, ref string) error {
 	if err != nil {
 		return fmt.Errorf("fetching tarball: %w", err)
 	}
+
+	files = filterLanguageFiles(files, dir)
 
 	m := &Manifest{
 		Version: commitSHA,
@@ -145,6 +154,8 @@ func Update(dir, owner, repo, ref string, force bool) error {
 	if err != nil {
 		return fmt.Errorf("fetching tarball: %w", err)
 	}
+
+	files = filterLanguageFiles(files, dir)
 
 	if currentVersion == commitSHA {
 		fmt.Println("Already up to date.")
@@ -552,6 +563,30 @@ func CustomizePlaceholderFiles(dir string) []string {
 		}
 	}
 	return files
+}
+
+// filterLanguageFiles removes language-specific instruction files when the
+// corresponding language is not detected in dir.
+func filterLanguageFiles(files []File, dir string) []File {
+	result := make([]File, 0, len(files))
+	for _, f := range files {
+		markers, ok := languageInstructionFiles[f.Path]
+		if ok && !hasAnyFile(dir, markers) {
+			continue
+		}
+		result = append(result, f)
+	}
+	return result
+}
+
+// hasAnyFile reports whether any of the named files exist in dir.
+func hasAnyFile(dir string, names []string) bool {
+	for _, name := range names {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func readManifest(dir string) (*Manifest, error) {

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -58,6 +58,7 @@ func sampleFrameworkContent() map[string]string {
 		".github/agents/roles/coder.md":    "# Coder role\n",
 		".github/skills/skill.md":          "# Skill\n",
 		".github/instructions/inst.md":     "# Instructions\n",
+		".github/instructions/go.instructions.md":    "# Go Guidelines\n",
 		".github/copilot-instructions.md":  "instructions\n",
 		".github/ISSUE_TEMPLATE/bug.md":    "# Bug\n",
 		".github/PULL_REQUEST_TEMPLATE.md": "# PR template\n",
@@ -605,6 +606,149 @@ func TestFrameworkFiles_NoScriptsReference(t *testing.T) {
 		if prefix == "Makefile" || prefix == "scripts/" {
 			t.Errorf("FrameworkFiles should not include %q — it references paths that do not exist after installation", prefix)
 		}
+	}
+}
+
+// -- Language-specific instruction file tests --
+
+func TestFilterLanguageFiles_KeepsGoInstructionsWhenGoModPresent(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example\n"), 0o644)
+
+	files := []File{
+		{Path: ".github/instructions/go.instructions.md", Data: []byte("# Go\n")},
+		{Path: ".editorconfig", Data: []byte("root = true\n")},
+	}
+	got := filterLanguageFiles(files, dir)
+	if len(got) != 2 {
+		t.Errorf("expected 2 files, got %d", len(got))
+	}
+}
+
+func TestFilterLanguageFiles_KeepsGoInstructionsWhenGoSumPresent(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "go.sum"), []byte("example v0.0.0\n"), 0o644)
+
+	files := []File{
+		{Path: ".github/instructions/go.instructions.md", Data: []byte("# Go\n")},
+		{Path: ".editorconfig", Data: []byte("root = true\n")},
+	}
+	got := filterLanguageFiles(files, dir)
+	if len(got) != 2 {
+		t.Errorf("expected 2 files, got %d", len(got))
+	}
+}
+
+func TestFilterLanguageFiles_DropsGoInstructionsWhenNoGoFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	files := []File{
+		{Path: ".github/instructions/go.instructions.md", Data: []byte("# Go\n")},
+		{Path: ".editorconfig", Data: []byte("root = true\n")},
+	}
+	got := filterLanguageFiles(files, dir)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(got))
+	}
+	if got[0].Path != ".editorconfig" {
+		t.Errorf("expected .editorconfig, got %q", got[0].Path)
+	}
+}
+
+func TestFilterLanguageFiles_KeepsNonLanguageFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	files := []File{
+		{Path: ".github/instructions/docs.instructions.md", Data: []byte("# Docs\n")},
+		{Path: ".editorconfig", Data: []byte("root = true\n")},
+	}
+	got := filterLanguageFiles(files, dir)
+	if len(got) != 2 {
+		t.Errorf("expected 2 files (non-language-specific), got %d", len(got))
+	}
+}
+
+func TestInstall_WithGoMod_GoInstructionsInstalled(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-create go.mod to simulate a Go project.
+	_ = os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example\n"), 0o644)
+
+	tb := makeTarball(testPrefix, sampleFrameworkContent())
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	goInstPath := filepath.Join(dir, ".github", "instructions", "go.instructions.md")
+	if _, err := os.Stat(goInstPath); err != nil {
+		t.Errorf("go.instructions.md should be installed in Go project: %v", err)
+	}
+}
+
+func TestInstall_WithoutGoMod_GoInstructionsNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	// No go.mod — not a Go project.
+
+	tb := makeTarball(testPrefix, sampleFrameworkContent())
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	goInstPath := filepath.Join(dir, ".github", "instructions", "go.instructions.md")
+	if _, err := os.Stat(goInstPath); !os.IsNotExist(err) {
+		t.Errorf("go.instructions.md should NOT be installed in non-Go project")
+	}
+}
+
+func TestUpdate_WithGoMod_GoInstructionsInstalled(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-create go.mod to simulate a Go project.
+	_ = os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example\n"), 0o644)
+
+	tb1 := makeTarball(testPrefix, map[string]string{
+		".editorconfig": "v1\n",
+	})
+	if err := serveAndInstall(t, dir, tb1); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	const newPrefix = "JoshLuedeman-teamwork-def5678def5678/"
+	tb2 := makeTarball(newPrefix, map[string]string{
+		".editorconfig":                           "v2\n",
+		".github/instructions/go.instructions.md": "# Go Guidelines\n",
+	})
+	if err := serveAndUpdate(t, dir, tb2, false); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	goInstPath := filepath.Join(dir, ".github", "instructions", "go.instructions.md")
+	if _, err := os.Stat(goInstPath); err != nil {
+		t.Errorf("go.instructions.md should be installed in Go project during update: %v", err)
+	}
+}
+
+func TestUpdate_WithoutGoMod_GoInstructionsNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	// No go.mod — not a Go project.
+
+	tb1 := makeTarball(testPrefix, map[string]string{
+		".editorconfig": "v1\n",
+	})
+	if err := serveAndInstall(t, dir, tb1); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	const newPrefix = "JoshLuedeman-teamwork-def5678def5678/"
+	tb2 := makeTarball(newPrefix, map[string]string{
+		".editorconfig":                           "v2\n",
+		".github/instructions/go.instructions.md": "# Go Guidelines\n",
+	})
+	if err := serveAndUpdate(t, dir, tb2, false); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	goInstPath := filepath.Join(dir, ".github", "instructions", "go.instructions.md")
+	if _, err := os.Stat(goInstPath); !os.IsNotExist(err) {
+		t.Errorf("go.instructions.md should NOT be installed in non-Go project during update")
 	}
 }
 


### PR DESCRIPTION
Fixes #130

## Summary

The installer was installing `go.instructions.md` in every project regardless of whether it uses Go. This PR adds language detection so that language-specific instruction files are only installed when the corresponding language is detected.

## Changes

- **`internal/installer/installer.go`**:
  - Added `languageInstructionFiles` map that defines which instruction files are language-specific and their marker files (`go.mod`, `go.sum` for Go)
  - Added `filterLanguageFiles()` function that filters out language-specific files when the language isn't detected
  - Added `hasAnyFile()` helper to check for marker file existence
  - Applied filtering in both `Install()` and `Update()` after fetching the tarball

- **`internal/installer/installer_test.go`**:
  - Added `go.instructions.md` to `sampleFrameworkContent()` test fixture
  - Added 4 unit tests for `filterLanguageFiles()` (go.mod present, go.sum present, no Go files, non-language files)
  - Added 2 integration tests for `Install()` (with and without go.mod)
  - Added 2 integration tests for `Update()` (with and without go.mod)

## Design

The `languageInstructionFiles` map is extensible — adding detection for other languages (Python, Node, etc.) only requires adding entries to the map.