### PR TITLE
feat(validate): add agent file linting and health checks

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -2,6 +2,7 @@
 package validate
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +43,7 @@ func Run(dir string) ([]Result, error) {
 	results = append(results, checkHandoffFiles(twDir)...)
 	results = append(results, checkMemoryFiles(twDir)...)
 	results = append(results, checkMCPServers(twDir)...)
+	results = append(results, checkAgentFiles(dir)...)
 
 	return results, nil
 }
@@ -312,6 +314,21 @@ var knownRoles = map[string]bool{
 	"qa-lead":            true,
 }
 
+// validModelTiers enumerates the recognized model tier values.
+var validModelTiers = map[string]bool{
+	"Premium":  true,
+	"Standard": true,
+	"Fast":     true,
+}
+
+// requiredAgentSections lists the ## headings every agent file must contain.
+var requiredAgentSections = []string{
+	"Identity",
+	"Responsibilities",
+	"Boundaries",
+	"Model Requirements",
+}
+
 // checkMCPServers validates the mcp_servers section of config.yaml, if present.
 func checkMCPServers(twDir string) []Result {
 	var results []Result
@@ -518,4 +535,170 @@ func checkMemoryFiles(twDir string) []Result {
 	})
 
 	return results
+}
+
+// checkAgentFiles validates all *.agent.md files under .github/agents/.
+func checkAgentFiles(dir string) []Result {
+	var results []Result
+	agentsDir := filepath.Join(dir, ".github", "agents")
+
+	if _, err := os.Stat(agentsDir); os.IsNotExist(err) {
+		// No agents directory — optional, skip silently.
+		return results
+	}
+
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		return results
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".agent.md") {
+			continue
+		}
+
+		path := filepath.Join(agentsDir, entry.Name())
+		relPath := ".github/agents/" + entry.Name()
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "agent_readable",
+				Passed:  false,
+				Message: fmt.Sprintf("%s: unreadable: %v", relPath, readErr),
+			})
+			continue
+		}
+
+		content := string(data)
+		results = append(results, validateAgentFile(relPath, content)...)
+	}
+
+	return results
+}
+
+// validateAgentFile runs all checks against a single agent file's content.
+func validateAgentFile(relPath, content string) []Result {
+	var results []Result
+
+	// 1. Check role name from frontmatter against knownRoles.
+	name := extractFrontmatterName(content)
+	if name == "" {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_role",
+			Passed:  false,
+			Message: fmt.Sprintf("%s: missing or empty 'name' in YAML frontmatter", relPath),
+		})
+	} else if !knownRoles[name] {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_role",
+			Passed:  false,
+			Message: fmt.Sprintf("%s: unknown role %q (not in known roles)", relPath, name),
+		})
+	} else {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_role",
+			Passed:  true,
+			Message: fmt.Sprintf("%s: valid role %q", relPath, name),
+		})
+	}
+
+	// 2. Check for required sections.
+	var missingSections []string
+	for _, section := range requiredAgentSections {
+		heading := "## " + section
+		if !strings.Contains(content, heading) {
+			missingSections = append(missingSections, section)
+		}
+	}
+	if len(missingSections) > 0 {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_sections",
+			Passed:  false,
+			Message: fmt.Sprintf("%s: missing required sections: %s", relPath, strings.Join(missingSections, ", ")),
+		})
+	} else {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_sections",
+			Passed:  true,
+			Message: relPath + ": has all required sections",
+		})
+	}
+
+	// 3. Check model tier reference.
+	tier := extractModelTier(content)
+	if tier == "" {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_model_tier",
+			Passed:  false,
+			Message: fmt.Sprintf("%s: no model tier found (expected '- **Tier:** <value>')", relPath),
+		})
+	} else if !validModelTiers[tier] {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_model_tier",
+			Passed:  false,
+			Message: fmt.Sprintf("%s: invalid model tier %q (valid: Premium, Standard, Fast)", relPath, tier),
+		})
+	} else {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_model_tier",
+			Passed:  true,
+			Message: fmt.Sprintf("%s: valid model tier %q", relPath, tier),
+		})
+	}
+
+	// 4. Check for unfilled CUSTOMIZE placeholders (warning, not failure).
+	if strings.Contains(content, "<!-- CUSTOMIZE") {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "agent_customized",
+			Passed:  true,
+			Message: fmt.Sprintf("%s: WARN unfilled CUSTOMIZE placeholder(s) found", relPath),
+		})
+	}
+
+	return results
+}
+
+// extractFrontmatterName parses the YAML frontmatter and returns the "name" field.
+func extractFrontmatterName(content string) string {
+	// Frontmatter is delimited by "---" lines.
+	if !strings.HasPrefix(content, "---") {
+		return ""
+	}
+	end := strings.Index(content[3:], "---")
+	if end < 0 {
+		return ""
+	}
+	fmBlock := content[3 : 3+end]
+
+	var fm struct {
+		Name string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal([]byte(fmBlock), &fm); err != nil {
+		return ""
+	}
+	return fm.Name
+}
+
+// extractModelTier scans for a line matching "- **Tier:** <value>" and returns the tier value.
+func extractModelTier(content string) string {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "- **Tier:**") {
+			tier := strings.TrimSpace(strings.TrimPrefix(line, "- **Tier:**"))
+			return tier
+		}
+	}
+	return ""
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -768,3 +768,369 @@ func contains(s, sub string) bool {
 			return false
 		}())
 }
+
+// --- Agent file validation tests ---
+
+// validAgentFile returns a minimal valid agent file with all required parts.
+func validAgentFile(name, tier string) string {
+	return `---
+name: ` + name + `
+description: Test agent
+---
+
+# Role: Test
+
+## Identity
+
+You are a test agent.
+
+## Model Requirements
+
+- **Tier:** ` + tier + `
+- **Why:** Test.
+- **Key capabilities needed:** Testing
+
+## Responsibilities
+
+- Do things
+
+## Boundaries
+
+- ✅ **Always:** Do the right thing
+`
+}
+
+// writeAgentFile writes an agent file into the test directory's .github/agents/.
+func writeAgentFile(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	agentDir := filepath.Join(dir, ".github", "agents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", agentDir, err)
+	}
+	path := filepath.Join(agentDir, filename)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// filterAgentResults returns only results with an agent-related Check.
+func filterAgentResults(results []validate.Result) []validate.Result {
+	var out []validate.Result
+	for _, r := range results {
+		if contains(r.Check, "agent_") {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestAgentFile_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+	writeAgentFile(t, dir, "coder.agent.md", validAgentFile("coder", "Premium"))
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+	if len(agentResults) == 0 {
+		t.Fatal("expected agent results, got none")
+	}
+	for _, r := range agentResults {
+		if !r.Passed {
+			t.Errorf("expected pass, got failure: %s", r.Message)
+		}
+	}
+}
+
+func TestAgentFile_CUSTOMIZEPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+
+	content := `---
+name: coder
+description: Test agent
+---
+
+# Role: Coder
+
+## Identity
+
+You are the Coder.
+
+## Project Knowledge
+<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
+- **Tech Stack:** [e.g., React 18]
+
+## Model Requirements
+
+- **Tier:** Premium
+- **Why:** Test
+
+## Responsibilities
+
+- Do things
+
+## Boundaries
+
+- Do things
+`
+	writeAgentFile(t, dir, "coder.agent.md", content)
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+
+	// Should have no failures (CUSTOMIZE is a warning, not a failure).
+	if countFailed(agentResults) != 0 {
+		t.Errorf("expected no failures for CUSTOMIZE placeholder (warning only), got: %v", failedMessages(agentResults))
+	}
+
+	// Should contain a WARN message about CUSTOMIZE.
+	foundWarn := false
+	for _, r := range agentResults {
+		if contains(r.Message, "WARN") && contains(r.Message, "CUSTOMIZE") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Error("expected a WARN message mentioning CUSTOMIZE")
+	}
+}
+
+func TestAgentFile_MissingSections(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+
+	// File with no required sections at all.
+	content := `---
+name: coder
+description: Missing sections
+---
+
+# Role: Coder
+
+## Model Requirements
+
+- **Tier:** Premium
+
+Some content but no Identity, Responsibilities, or Boundaries sections.
+`
+	writeAgentFile(t, dir, "coder.agent.md", content)
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+
+	// Should have a failure for missing sections.
+	msgs := failedMessages(agentResults)
+	found := false
+	for _, m := range msgs {
+		if contains(m, "missing required sections") {
+			found = true
+			// Should mention Identity, Responsibilities, and Boundaries.
+			if !contains(m, "Identity") {
+				t.Errorf("expected missing section 'Identity' mentioned, got: %s", m)
+			}
+			if !contains(m, "Responsibilities") {
+				t.Errorf("expected missing section 'Responsibilities' mentioned, got: %s", m)
+			}
+			if !contains(m, "Boundaries") {
+				t.Errorf("expected missing section 'Boundaries' mentioned, got: %s", m)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected failure mentioning 'missing required sections', got: %v", msgs)
+	}
+}
+
+func TestAgentFile_UnknownRole(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+	writeAgentFile(t, dir, "wizard.agent.md", validAgentFile("wizard", "Premium"))
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+
+	msgs := failedMessages(agentResults)
+	found := false
+	for _, m := range msgs {
+		if contains(m, "unknown role") && contains(m, "wizard") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected failure mentioning unknown role 'wizard', got: %v", msgs)
+	}
+}
+
+func TestAgentFile_InvalidModelTier(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+	writeAgentFile(t, dir, "coder.agent.md", validAgentFile("coder", "Ultra"))
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+
+	msgs := failedMessages(agentResults)
+	found := false
+	for _, m := range msgs {
+		if contains(m, "invalid model tier") && contains(m, "Ultra") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected failure mentioning invalid model tier 'Ultra', got: %v", msgs)
+	}
+}
+
+func TestAgentFile_MissingFrontmatterName(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+
+	content := `---
+description: No name field
+---
+
+# Role: Mystery
+
+## Identity
+
+You are nobody.
+
+## Model Requirements
+
+- **Tier:** Standard
+
+## Responsibilities
+
+- Nothing
+
+## Boundaries
+
+- None
+`
+	writeAgentFile(t, dir, "mystery.agent.md", content)
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+
+	msgs := failedMessages(agentResults)
+	found := false
+	for _, m := range msgs {
+		if contains(m, "missing or empty") && contains(m, "name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected failure mentioning missing 'name', got: %v", msgs)
+	}
+}
+
+func TestAgentFile_MissingModelTier(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+
+	content := `---
+name: coder
+description: No tier
+---
+
+# Role: Coder
+
+## Identity
+
+You are the Coder.
+
+## Model Requirements
+
+No tier line here.
+
+## Responsibilities
+
+- Do things
+
+## Boundaries
+
+- Do things
+`
+	writeAgentFile(t, dir, "coder.agent.md", content)
+
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+
+	msgs := failedMessages(agentResults)
+	found := false
+	for _, m := range msgs {
+		if contains(m, "no model tier found") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected failure mentioning 'no model tier found', got: %v", msgs)
+	}
+}
+
+func TestAgentFile_NoAgentsDir(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+	writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+
+	// No .github/agents/ directory at all — should pass silently.
+	results, err := validate.Run(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	agentResults := filterAgentResults(results)
+	if len(agentResults) != 0 {
+		t.Errorf("expected no agent results when directory is absent, got %d: %+v", len(agentResults), agentResults)
+	}
+}
+
+func TestAgentFile_AllValidTiers(t *testing.T) {
+	tiers := []string{"Premium", "Standard", "Fast"}
+	for _, tier := range tiers {
+		t.Run(tier, func(t *testing.T) {
+			dir := t.TempDir()
+			os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
+			writeFile(t, dir, ".teamwork/config.yaml", validConfig())
+			writeAgentFile(t, dir, "coder.agent.md", validAgentFile("coder", tier))
+
+			results, err := validate.Run(dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			agentResults := filterAgentResults(results)
+			for _, r := range agentResults {
+				if !r.Passed {
+					t.Errorf("tier %q: expected pass, got failure: %s", tier, r.Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds validation for `.github/agents/*.agent.md` files to the `teamwork validate` command.

### Checks added

- **Role name** — verifies frontmatter `name:` field matches a known role
- **Required sections** — checks for `## Identity`, `## Responsibilities`, `## Boundaries`, `## Model Requirements`
- **Model tier** — validates `- **Tier:**` value is one of `Premium`, `Standard`, `Fast`

### Tests added

- Valid agent file (all checks pass)
- CUSTOMIZE placeholder detection (warning, not failure)
- Missing required sections
- Unknown role name
- Invalid model tier
- Missing frontmatter name
- Missing model tier line
- No agents directory (silent pass)
- All valid tier values (Premium, Standard, Fast)

Fixes #117