### PR TITLE
feat(cli): add config presets for popular stacks

### DIFF
--- a/cmd/teamwork/cmd/init.go
+++ b/cmd/teamwork/cmd/init.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/joshluedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/presets"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ var initCmd = &cobra.Command{
 
 func init() {
 	initCmd.Flags().Bool("non-interactive", false, "Skip interactive wizard even when stdin is a TTY")
+	initCmd.Flags().String("preset", "", "Use a preset config for a specific stack ("+strings.Join(presets.Names(), ", ")+")")
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -34,6 +36,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	presetName, err := cmd.Flags().GetString("preset")
+	if err != nil {
+		return err
+	}
 
 	teamworkDir := filepath.Join(dir, ".teamwork")
 
@@ -44,7 +50,16 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("checking .teamwork/: %w", err)
 	}
 
-	cfg := config.Default()
+	var cfg *config.Config
+	if presetName != "" {
+		cfg, err = presets.Get(presetName)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Using preset: %s\n", presetName)
+	} else {
+		cfg = config.Default()
+	}
 
 	// Interactive prompts when stdin is a TTY and not explicitly disabled.
 	if !nonInteractive && isInteractive() {

--- a/cmd/teamwork/cmd/init_test.go
+++ b/cmd/teamwork/cmd/init_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/joshluedeman/teamwork/internal/config"
 	"github.com/joshluedeman/teamwork/internal/memory"
+	"github.com/joshluedeman/teamwork/internal/presets"
 )
 
 func TestRunInit_NonInteractive_CreatesDefaultConfig(t *testing.T) {
@@ -285,5 +286,86 @@ func TestRunWizard_PartialCustomValues(t *testing.T) {
 	}
 	if result.Project.Repo != "owner/repo" {
 		t.Errorf("project repo = %q, want default %q", result.Project.Repo, "owner/repo")
+	}
+}
+
+func TestRunInit_WithPreset_UsesPresetConfig(t *testing.T) {
+	for _, name := range presets.Names() {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			cmd := rootCmd
+			cmd.SetArgs([]string{"init", "--dir", dir, "--preset", name})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("init --preset %s failed: %v", name, err)
+			}
+			cfg, err := config.Load(dir)
+			if err != nil {
+				t.Fatalf("loading config: %v", err)
+			}
+			if len(cfg.Roles.Core) == 0 {
+				t.Error("preset config has no core roles")
+			}
+			if len(cfg.MCPServers) == 0 {
+				t.Error("preset config has no MCP servers")
+			}
+			if _, ok := cfg.MCPServers["github"]; !ok {
+				t.Error("preset config missing github MCP server")
+			}
+		})
+	}
+}
+
+func TestRunInit_WithPreset_GoAPI_HasDevOps(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir, "--preset", "go-api"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --preset go-api failed: %v", err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	found := false
+	for _, role := range cfg.Roles.Optional {
+		if role == "devops" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("go-api preset should include devops in optional roles, got %v", cfg.Roles.Optional)
+	}
+}
+
+func TestRunInit_WithInvalidPreset_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir, "--preset", "nonexistent"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("init --preset nonexistent should return an error")
+	}
+	if !strings.Contains(err.Error(), "unknown preset") {
+		t.Errorf("error should mention 'unknown preset', got: %v", err)
+	}
+}
+
+func TestRunInit_WithoutPreset_PreservesDefaultBehavior(t *testing.T) {
+	dir := t.TempDir()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"init", "--dir", dir, "--preset", ""})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Project.Name != "my-project" {
+		t.Errorf("project name = %q, want %q", cfg.Project.Name, "my-project")
+	}
+	if len(cfg.MCPServers) != 0 {
+		t.Errorf("default config should have no MCP servers, got %d", len(cfg.MCPServers))
 	}
 }

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -1,0 +1,275 @@
+// Package presets provides pre-built configuration templates for common
+// technology stacks.  Each preset returns a *config.Config that pre-fills
+// roles, quality gates, skip-step rules and MCP server suggestions so that
+// `teamwork init --preset <name>` gives users a useful starting point.
+package presets
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/joshluedeman/teamwork/internal/config"
+)
+
+// Names returns the sorted list of available preset identifiers.
+func Names() []string {
+	names := make([]string, 0, len(registry))
+	for k := range registry {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Get returns the Config for a named preset.  It returns an error if the
+// name is not recognized.
+func Get(name string) (*config.Config, error) {
+	fn, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown preset %q (available: %v)", name, Names())
+	}
+	return fn(), nil
+}
+
+// registry maps preset names to builder functions.
+var registry = map[string]func() *config.Config{
+	"go-api":    goAPI,
+	"react-ts":  reactTS,
+	"python-ml": pythonML,
+	"fullstack": fullstack,
+}
+
+func coreRoles() []string {
+	return []string{
+		"planner", "architect", "coder", "tester",
+		"reviewer", "security-auditor", "documenter", "orchestrator",
+	}
+}
+
+func defaultMemory() config.MemoryConfig {
+	return config.MemoryConfig{
+		ArchiveThreshold: 50,
+		SyncToMemoryMD:   true,
+	}
+}
+
+func mcpGitHub() config.MCPServer {
+	return config.MCPServer{
+		Description: "GitHub repos, PRs, issues, CI workflows, Dependabot alerts",
+		URL:         "https://api.githubcopilot.com/mcp/",
+		Roles:       []string{"planner", "architect", "coder", "tester", "reviewer", "security-auditor", "documenter", "orchestrator"},
+		EnvVars:     []string{"GH_TOKEN"},
+		Install:     "gh extension install github/gh-mcp",
+	}
+}
+
+func mcpContext7() config.MCPServer {
+	return config.MCPServer{
+		Description: "Real-time library documentation",
+		URL:         "https://mcp.context7.com/mcp",
+		Roles:       []string{"architect", "coder", "documenter"},
+		EnvVars:     []string{},
+		Install:     "npx -y @upstash/context7-mcp",
+	}
+}
+
+func mcpSemgrep() config.MCPServer {
+	return config.MCPServer{
+		Description: "SAST security scanning",
+		Command:     "uvx semgrep-mcp",
+		Roles:       []string{"security-auditor", "reviewer", "coder"},
+		EnvVars:     []string{"SEMGREP_APP_TOKEN"},
+		Install:     "pip install semgrep-mcp",
+	}
+}
+
+func mcpE2B() config.MCPServer {
+	return config.MCPServer{
+		Description: "Cloud-sandboxed Python and JavaScript code execution",
+		Command:     "uvx e2b-mcp",
+		Roles:       []string{"coder", "tester"},
+		EnvVars:     []string{"E2B_API_KEY"},
+		Install:     "pip install e2b-mcp",
+	}
+}
+
+func mcpOSV() config.MCPServer {
+	return config.MCPServer{
+		Description: "Open Source Vulnerability database",
+		Command:     "uvx osv-mcp",
+		Roles:       []string{"security-auditor", "reviewer"},
+		EnvVars:     []string{},
+		Install:     "pip install osv-mcp",
+	}
+}
+
+func mcpCoverage() config.MCPServer {
+	return config.MCPServer{
+		Description: "Test coverage report analysis",
+		Command:     "uvx teamwork-mcp-coverage",
+		Roles:       []string{"tester", "reviewer", "orchestrator"},
+		EnvVars:     []string{},
+		Install:     "pip install teamwork-mcp-coverage",
+	}
+}
+
+func mcpCommits() config.MCPServer {
+	return config.MCPServer{
+		Description: "Conventional commit message generation and validation from diffs",
+		Command:     "uvx teamwork-mcp-commits",
+		Roles:       []string{"coder", "reviewer", "orchestrator"},
+		EnvVars:     []string{},
+		Install:     "pip install teamwork-mcp-commits",
+	}
+}
+
+func mcpADR() config.MCPServer {
+	return config.MCPServer{
+		Description: "Architecture Decision Record search, creation, and management",
+		Command:     "uvx teamwork-mcp-adr",
+		Roles:       []string{"architect", "orchestrator", "coder"},
+		EnvVars:     []string{},
+		Install:     "pip install teamwork-mcp-adr",
+	}
+}
+
+func mcpChangelog() config.MCPServer {
+	return config.MCPServer{
+		Description: "Changelog generation and release notes using git-cliff",
+		Command:     "uvx teamwork-mcp-changelog",
+		Roles:       []string{"documenter", "orchestrator", "planner"},
+		EnvVars:     []string{},
+		Install:     "pip install teamwork-mcp-changelog",
+	}
+}
+
+func mcpComplexity() config.MCPServer {
+	return config.MCPServer{
+		Description: "Code complexity analysis",
+		Command:     "uvx teamwork-mcp-complexity",
+		Roles:       []string{"reviewer", "tester", "architect"},
+		EnvVars:     []string{},
+		Install:     "pip install teamwork-mcp-complexity",
+	}
+}
+
+// goAPI returns a config tuned for Go API/backend projects.
+func goAPI() *config.Config {
+	return &config.Config{
+		Project: config.ProjectConfig{Name: "my-project", Repo: "owner/repo"},
+		Roles: config.RolesConfig{
+			Core:     coreRoles(),
+			Optional: []string{"devops"},
+		},
+		Workflows: config.WorkflowsConfig{
+			SkipSteps: map[string][]string{
+				"documentation": {"security-auditor"},
+				"spike":         {"tester", "security-auditor"},
+			},
+			ExtraGates: map[string]map[string][]string{},
+		},
+		QualityGates: config.QualityGatesConfig{HandoffComplete: true, TestsPass: true, LintPass: true},
+		Memory:       defaultMemory(),
+		MCPServers: map[string]config.MCPServer{
+			"github":     mcpGitHub(),
+			"context7":   mcpContext7(),
+			"semgrep":    mcpSemgrep(),
+			"osv":        mcpOSV(),
+			"coverage":   mcpCoverage(),
+			"commits":    mcpCommits(),
+			"adr":        mcpADR(),
+			"complexity": mcpComplexity(),
+		},
+	}
+}
+
+// reactTS returns a config tuned for React + TypeScript frontend projects.
+func reactTS() *config.Config {
+	return &config.Config{
+		Project: config.ProjectConfig{Name: "my-project", Repo: "owner/repo"},
+		Roles: config.RolesConfig{
+			Core:     coreRoles(),
+			Optional: []string{},
+		},
+		Workflows: config.WorkflowsConfig{
+			SkipSteps: map[string][]string{
+				"documentation": {"security-auditor"},
+				"spike":         {"tester", "security-auditor"},
+			},
+			ExtraGates: map[string]map[string][]string{},
+		},
+		QualityGates: config.QualityGatesConfig{HandoffComplete: true, TestsPass: true, LintPass: true},
+		Memory:       defaultMemory(),
+		MCPServers: map[string]config.MCPServer{
+			"github":     mcpGitHub(),
+			"context7":   mcpContext7(),
+			"semgrep":    mcpSemgrep(),
+			"e2b":        mcpE2B(),
+			"commits":    mcpCommits(),
+			"complexity": mcpComplexity(),
+		},
+	}
+}
+
+// pythonML returns a config tuned for Python machine-learning projects.
+func pythonML() *config.Config {
+	return &config.Config{
+		Project: config.ProjectConfig{Name: "my-project", Repo: "owner/repo"},
+		Roles: config.RolesConfig{
+			Core:     coreRoles(),
+			Optional: []string{},
+		},
+		Workflows: config.WorkflowsConfig{
+			SkipSteps: map[string][]string{
+				"documentation": {"security-auditor"},
+				"spike":         {"tester", "security-auditor"},
+				"refactor":      {"security-auditor"},
+			},
+			ExtraGates: map[string]map[string][]string{},
+		},
+		QualityGates: config.QualityGatesConfig{HandoffComplete: true, TestsPass: true, LintPass: true},
+		Memory:       defaultMemory(),
+		MCPServers: map[string]config.MCPServer{
+			"github":     mcpGitHub(),
+			"context7":   mcpContext7(),
+			"semgrep":    mcpSemgrep(),
+			"e2b":        mcpE2B(),
+			"osv":        mcpOSV(),
+			"commits":    mcpCommits(),
+			"complexity": mcpComplexity(),
+		},
+	}
+}
+
+// fullstack returns a config tuned for full-stack projects with both
+// frontend and backend components.
+func fullstack() *config.Config {
+	return &config.Config{
+		Project: config.ProjectConfig{Name: "my-project", Repo: "owner/repo"},
+		Roles: config.RolesConfig{
+			Core:     coreRoles(),
+			Optional: []string{"devops", "dependency-manager"},
+		},
+		Workflows: config.WorkflowsConfig{
+			SkipSteps: map[string][]string{
+				"documentation": {"security-auditor"},
+				"spike":         {"tester", "security-auditor"},
+			},
+			ExtraGates: map[string]map[string][]string{},
+		},
+		QualityGates: config.QualityGatesConfig{HandoffComplete: true, TestsPass: true, LintPass: true},
+		Memory:       defaultMemory(),
+		MCPServers: map[string]config.MCPServer{
+			"github":     mcpGitHub(),
+			"context7":   mcpContext7(),
+			"semgrep":    mcpSemgrep(),
+			"e2b":        mcpE2B(),
+			"osv":        mcpOSV(),
+			"coverage":   mcpCoverage(),
+			"commits":    mcpCommits(),
+			"adr":        mcpADR(),
+			"changelog":  mcpChangelog(),
+			"complexity": mcpComplexity(),
+		},
+	}
+}

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -1,0 +1,194 @@
+package presets
+
+import (
+	"testing"
+)
+
+func TestNames_ReturnsAllPresets(t *testing.T) {
+	names := Names()
+	expected := []string{"fullstack", "go-api", "python-ml", "react-ts"}
+	if len(names) != len(expected) {
+		t.Fatalf("Names() returned %d presets, want %d", len(names), len(expected))
+	}
+	for i, name := range expected {
+		if names[i] != name {
+			t.Errorf("Names()[%d] = %q, want %q", i, names[i], name)
+		}
+	}
+}
+
+func TestNames_IsSorted(t *testing.T) {
+	names := Names()
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("Names() not sorted: %q comes after %q", names[i], names[i-1])
+		}
+	}
+}
+
+func TestGet_UnknownPreset(t *testing.T) {
+	_, err := Get("nonexistent")
+	if err == nil {
+		t.Fatal("Get(nonexistent) should return an error")
+	}
+}
+
+func TestGet_AllPresetsReturnValidConfig(t *testing.T) {
+	for _, name := range Names() {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := Get(name)
+			if err != nil {
+				t.Fatalf("Get(%q) error: %v", name, err)
+			}
+			if cfg == nil {
+				t.Fatalf("Get(%q) returned nil config", name)
+			}
+			if cfg.Project.Name != "my-project" {
+				t.Errorf("project.name = %q, want %q", cfg.Project.Name, "my-project")
+			}
+			if cfg.Project.Repo != "owner/repo" {
+				t.Errorf("project.repo = %q, want %q", cfg.Project.Repo, "owner/repo")
+			}
+			if len(cfg.Roles.Core) == 0 {
+				t.Error("core roles are empty")
+			}
+			if cfg.Roles.Optional == nil {
+				t.Error("optional roles is nil, want non-nil slice")
+			}
+			if !cfg.QualityGates.HandoffComplete {
+				t.Error("quality_gates.handoff_complete should be true")
+			}
+			if !cfg.QualityGates.TestsPass {
+				t.Error("quality_gates.tests_pass should be true")
+			}
+			if !cfg.QualityGates.LintPass {
+				t.Error("quality_gates.lint_pass should be true")
+			}
+			if cfg.Memory.ArchiveThreshold != 50 {
+				t.Errorf("memory.archive_threshold = %d, want 50", cfg.Memory.ArchiveThreshold)
+			}
+			if _, ok := cfg.MCPServers["github"]; !ok {
+				t.Error("mcp_servers missing github")
+			}
+			if cfg.Workflows.SkipSteps == nil {
+				t.Error("workflows.skip_steps is nil")
+			}
+			if cfg.Workflows.ExtraGates == nil {
+				t.Error("workflows.extra_gates is nil")
+			}
+		})
+	}
+}
+
+func TestGoAPI_HasExpectedMCPServers(t *testing.T) {
+	cfg, err := Get("go-api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"github", "context7", "semgrep", "osv", "coverage", "commits", "adr", "complexity"}
+	for _, name := range expected {
+		if _, ok := cfg.MCPServers[name]; !ok {
+			t.Errorf("go-api preset missing MCP server %q", name)
+		}
+	}
+	if _, ok := cfg.MCPServers["e2b"]; ok {
+		t.Error("go-api preset should not include e2b")
+	}
+}
+
+func TestGoAPI_HasDevOpsOptionalRole(t *testing.T) {
+	cfg, err := Get("go-api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Roles.Optional) != 1 || cfg.Roles.Optional[0] != "devops" {
+		t.Errorf("go-api optional roles = %v, want [devops]", cfg.Roles.Optional)
+	}
+}
+
+func TestReactTS_HasExpectedMCPServers(t *testing.T) {
+	cfg, err := Get("react-ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"github", "context7", "semgrep", "e2b", "commits", "complexity"}
+	for _, name := range expected {
+		if _, ok := cfg.MCPServers[name]; !ok {
+			t.Errorf("react-ts preset missing MCP server %q", name)
+		}
+	}
+	if _, ok := cfg.MCPServers["coverage"]; ok {
+		t.Error("react-ts preset should not include coverage")
+	}
+}
+
+func TestReactTS_NoOptionalRoles(t *testing.T) {
+	cfg, err := Get("react-ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Roles.Optional) != 0 {
+		t.Errorf("react-ts optional roles = %v, want empty", cfg.Roles.Optional)
+	}
+}
+
+func TestPythonML_HasExpectedMCPServers(t *testing.T) {
+	cfg, err := Get("python-ml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"github", "context7", "semgrep", "e2b", "osv", "commits", "complexity"}
+	for _, name := range expected {
+		if _, ok := cfg.MCPServers[name]; !ok {
+			t.Errorf("python-ml preset missing MCP server %q", name)
+		}
+	}
+}
+
+func TestPythonML_SkipsSecurityAuditorOnRefactor(t *testing.T) {
+	cfg, err := Get("python-ml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.ShouldSkipStep("refactor", "security-auditor") {
+		t.Error("python-ml should skip security-auditor for refactor workflows")
+	}
+}
+
+func TestFullstack_HasExpectedMCPServers(t *testing.T) {
+	cfg, err := Get("fullstack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"github", "context7", "semgrep", "e2b", "osv", "coverage", "commits", "adr", "changelog", "complexity"}
+	for _, name := range expected {
+		if _, ok := cfg.MCPServers[name]; !ok {
+			t.Errorf("fullstack preset missing MCP server %q", name)
+		}
+	}
+}
+
+func TestFullstack_HasExpectedOptionalRoles(t *testing.T) {
+	cfg, err := Get("fullstack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"devops": true, "dependency-manager": true}
+	if len(cfg.Roles.Optional) != len(want) {
+		t.Fatalf("fullstack optional roles = %v, want %v", cfg.Roles.Optional, want)
+	}
+	for _, role := range cfg.Roles.Optional {
+		if !want[role] {
+			t.Errorf("unexpected optional role %q", role)
+		}
+	}
+}
+
+func TestPresetsAreIndependent(t *testing.T) {
+	cfg1, _ := Get("go-api")
+	cfg2, _ := Get("go-api")
+	cfg1.Project.Name = "mutated"
+	if cfg2.Project.Name == "mutated" {
+		t.Error("modifying one preset config affected another")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `--preset` flag to `teamwork init` that pre-fills config with stack-appropriate roles, quality gates, skip-step rules, and MCP server suggestions.

### Available presets

| Preset | Stack | Optional Roles | MCP Servers | Notes |
|--------|-------|---------------|-------------|-------|
| `go-api` | Go API/backend | devops | github, context7, semgrep, osv, coverage, commits, adr, complexity | Coverage + ADR for Go projects |
| `react-ts` | React + TypeScript | — | github, context7, semgrep, e2b, commits, complexity | E2B sandbox for JS execution |
| `python-ml` | Python ML | — | github, context7, semgrep, e2b, osv, commits, complexity | Skips security-auditor on refactors |
| `fullstack` | Full-stack | devops, dependency-manager | github, context7, semgrep, e2b, osv, coverage, commits, adr, changelog, complexity | Comprehensive for multi-layer projects |

### Usage

```bash
teamwork init --preset go-api
```

Without `--preset`, init behaves exactly as before (backward compatible).

### Changes

- **New**: `internal/presets/` package with preset definitions and tests (13 tests)
- **Modified**: `cmd/teamwork/cmd/init.go` — added `--preset` flag support
- **Modified**: `cmd/teamwork/cmd/init_test.go` — added 5 tests for preset behavior

Fixes #121