### PR TITLE
feat(workflow): support custom workflow definitions in config

### DIFF
--- a/cmd/teamwork/cmd/start.go
+++ b/cmd/teamwork/cmd/start.go
@@ -32,14 +32,18 @@ func runStart(cmd *cobra.Command, args []string) error {
 	wfType := args[0]
 	goal := strings.Join(args[1:], " ")
 
-	if !isKnownType(wfType) {
-		return fmt.Errorf("unknown workflow type %q — must be one of: %s",
-			wfType, strings.Join(knownWorkflowTypes, ", "))
-	}
-
 	dir, err := cmd.Flags().GetString("dir")
 	if err != nil {
 		return err
+	}
+
+	// Check built-in types first; if not found, check custom workflows in config.
+	if !isKnownType(wfType) {
+		cfg, cfgErr := config.Load(dir)
+		if cfgErr != nil || !cfg.HasCustomWorkflow(wfType) {
+			return fmt.Errorf("unknown workflow type %q — must be one of: %s (or define a custom workflow in config)",
+				wfType, strings.Join(knownWorkflowTypes, ", "))
+		}
 	}
 
 	dryRun, err := cmd.Flags().GetBool("dry-run")
@@ -79,12 +83,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 // runDryRun previews the workflow steps without creating state files.
 func runDryRun(cmd *cobra.Command, dir, wfType, goal string) error {
-	steps, err := workflow.PreviewSteps(wfType)
+	cfg, err := config.Load(dir)
 	if err != nil {
 		return err
 	}
 
-	cfg, err := config.Load(dir)
+	steps, err := workflow.PreviewStepsWithConfig(cfg, wfType)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,19 @@ type Config struct {
 	QualityGates QualityGatesConfig   `yaml:"quality_gates"`
 	Memory       MemoryConfig         `yaml:"memory"`
 	MCPServers   map[string]MCPServer `yaml:"mcp_servers"`
-	Repos        []RepoConfig         `yaml:"repos,omitempty"`
+	Repos           []RepoConfig              `yaml:"repos,omitempty"`
+	CustomWorkflows map[string]CustomWorkflow `yaml:"custom_workflows,omitempty"`
+}
+
+// CustomWorkflow describes a user-defined workflow with a custom step sequence.
+type CustomWorkflow struct {
+	Steps []CustomStep `yaml:"steps"`
+}
+
+// CustomStep describes a single step in a custom workflow definition.
+type CustomStep struct {
+	Role        string `yaml:"role"`
+	Description string `yaml:"description"`
 }
 
 // ProjectConfig identifies the project.
@@ -185,4 +197,14 @@ func (c *Config) GetRepo(name string) *RepoConfig {
 		}
 	}
 	return nil
+}
+
+// HasCustomWorkflow reports whether a custom workflow with the given name
+// is defined in the config.
+func (c *Config) HasCustomWorkflow(name string) bool {
+	if c.CustomWorkflows == nil {
+		return false
+	}
+	_, ok := c.CustomWorkflows[name]
+	return ok
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,3 +115,46 @@ func TestGetRepo(t *testing.T) {
 		t.Errorf("GetRepo(missing) = %v, want nil", r)
 	}
 }
+
+func TestLoadWithCustomWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\ncustom_workflows:\n  data-pipeline:\n    steps:\n      - role: planner\n        description: Design the pipeline\n      - role: coder\n        description: Build the pipeline\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	got, err := Load(dir)
+	if err != nil { t.Fatalf("Load() error = %v", err) }
+	if got.CustomWorkflows == nil { t.Fatal("CustomWorkflows is nil") }
+	cw, ok := got.CustomWorkflows["data-pipeline"]
+	if !ok { t.Fatal("data-pipeline not found") }
+	if len(cw.Steps) != 2 { t.Fatalf("Steps = %d, want 2", len(cw.Steps)) }
+	if cw.Steps[0].Role != "planner" { t.Errorf("Role = %q, want planner", cw.Steps[0].Role) }
+}
+
+func TestLoadWithoutCustomWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	got, err := Load(dir)
+	if err != nil { t.Fatalf("Load() error = %v", err) }
+	if got.CustomWorkflows != nil && len(got.CustomWorkflows) != 0 {
+		t.Errorf("CustomWorkflows = %v, want nil or empty", got.CustomWorkflows)
+	}
+}
+
+func TestHasCustomWorkflow(t *testing.T) {
+	cfg := &Config{
+		CustomWorkflows: map[string]CustomWorkflow{
+			"my-flow": {Steps: []CustomStep{{Role: "coder", Description: "code"}}},
+		},
+	}
+	if !cfg.HasCustomWorkflow("my-flow") { t.Error("expected true") }
+	if cfg.HasCustomWorkflow("missing") { t.Error("expected false") }
+}
+
+func TestHasCustomWorkflow_NilMap(t *testing.T) {
+	cfg := &Config{}
+	if cfg.HasCustomWorkflow("anything") { t.Error("expected false for nil") }
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -39,6 +39,7 @@ func Run(dir string) ([]Result, error) {
 	var results []Result
 
 	results = append(results, checkConfigExists(twDir)...)
+	results = append(results, checkCustomWorkflows(twDir)...)
 	results = append(results, checkStateFiles(twDir)...)
 	results = append(results, checkHandoffFiles(twDir)...)
 	results = append(results, checkMemoryFiles(twDir)...)
@@ -289,6 +290,129 @@ func checkHandoffFiles(twDir string) []Result {
 
 		return nil
 	})
+
+	return results
+}
+
+// builtinWorkflowTypes lists the built-in workflow type names for conflict detection.
+var builtinWorkflowTypes = map[string]bool{
+	"feature": true, "bugfix": true, "refactor": true, "hotfix": true,
+	"security-response": true, "dependency-update": true,
+	"documentation": true, "spike": true, "release": true, "rollback": true,
+}
+
+// checkCustomWorkflows validates the custom_workflows section of config.yaml, if present.
+func checkCustomWorkflows(twDir string) []Result {
+	var results []Result
+	cfgPath := filepath.Join(twDir, "config.yaml")
+	relPath := ".teamwork/config.yaml"
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return results
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return results
+	}
+
+	cwRaw, ok := raw["custom_workflows"]
+	if !ok {
+		return results
+	}
+
+	workflows, _ := cwRaw.(map[string]interface{})
+	if workflows == nil {
+		return results
+	}
+
+	validCount := 0
+	for name, entry := range workflows {
+		wf, _ := entry.(map[string]interface{})
+		if wf == nil {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "custom_workflows",
+				Passed:  false,
+				Message: fmt.Sprintf("custom_workflows.%s: invalid workflow entry", name),
+			})
+			continue
+		}
+
+		if builtinWorkflowTypes[name] {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "custom_workflows",
+				Passed:  false,
+				Message: fmt.Sprintf("custom_workflows.%s: conflicts with built-in workflow type", name),
+			})
+			continue
+		}
+
+		stepsRaw, _ := wf["steps"].([]interface{})
+		if len(stepsRaw) == 0 {
+			results = append(results, Result{
+				Path:    relPath,
+				Check:   "custom_workflows",
+				Passed:  false,
+				Message: fmt.Sprintf("custom_workflows.%s: must have at least one step", name),
+			})
+			continue
+		}
+
+		stepValid := true
+		for i, stepRaw := range stepsRaw {
+			step, _ := stepRaw.(map[string]interface{})
+			if step == nil {
+				results = append(results, Result{
+					Path:    relPath,
+					Check:   "custom_workflows",
+					Passed:  false,
+					Message: fmt.Sprintf("custom_workflows.%s: step %d is invalid", name, i+1),
+				})
+				stepValid = false
+				break
+			}
+
+			role, _ := step["role"].(string)
+			if role == "" {
+				results = append(results, Result{
+					Path:    relPath,
+					Check:   "custom_workflows",
+					Passed:  false,
+					Message: fmt.Sprintf("custom_workflows.%s: step %d missing required field 'role'", name, i+1),
+				})
+				stepValid = false
+				break
+			}
+
+			desc, _ := step["description"].(string)
+			if desc == "" {
+				results = append(results, Result{
+					Path:    relPath,
+					Check:   "custom_workflows",
+					Passed:  false,
+					Message: fmt.Sprintf("custom_workflows.%s: step %d missing required field 'description'", name, i+1),
+				})
+				stepValid = false
+				break
+			}
+		}
+
+		if stepValid {
+			validCount++
+		}
+	}
+
+	if validCount > 0 {
+		results = append(results, Result{
+			Path:    relPath,
+			Check:   "custom_workflows",
+			Passed:  true,
+			Message: fmt.Sprintf("custom_workflows: %d custom workflows defined", validCount),
+		})
+	}
 
 	return results
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,6 +1,7 @@
 package validate_test
 
 import (
+	"strings"
 	"os"
 	"path/filepath"
 	"testing"
@@ -824,6 +825,14 @@ func filterAgentResults(results []validate.Result) []validate.Result {
 	return out
 }
 
+func filterCustomWorkflowResults(results []validate.Result) []validate.Result {
+	var out []validate.Result
+	for _, r := range results {
+		if r.Check == "custom_workflows" { out = append(out, r) }
+	}
+	return out
+}
+
 func TestAgentFile_ValidFile(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, ".teamwork"), 0o755)
@@ -1133,4 +1142,74 @@ func TestAgentFile_AllValidTiers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRun_ValidCustomWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\ncustom_workflows:\n  data-pipeline:\n    steps:\n      - role: planner\n        description: Design\n      - role: coder\n        description: Build\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	results, _ := validate.Run(dir)
+	cwResults := filterCustomWorkflowResults(results)
+	if len(cwResults) == 0 { t.Fatal("expected results") }
+	for _, r := range cwResults {
+		if !r.Passed { t.Errorf("expected pass: %s", r.Message) }
+	}
+}
+
+func TestRun_CustomWorkflowConflictsWithBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\ncustom_workflows:\n  feature:\n    steps:\n      - role: coder\n        description: Override\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	results, _ := validate.Run(dir)
+	cwResults := filterCustomWorkflowResults(results)
+	found := false
+	for _, r := range cwResults {
+		if !r.Passed && strings.Contains(r.Message, "conflicts with built-in") { found = true }
+	}
+	if !found { t.Error("expected conflict") }
+}
+
+func TestRun_CustomWorkflowEmptySteps(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\ncustom_workflows:\n  empty-wf:\n    steps: []\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	results, _ := validate.Run(dir)
+	cwResults := filterCustomWorkflowResults(results)
+	found := false
+	for _, r := range cwResults {
+		if !r.Passed && strings.Contains(r.Message, "at least one step") { found = true }
+	}
+	if !found { t.Error("expected error for empty steps") }
+}
+
+func TestRun_CustomWorkflowMissingRole(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\ncustom_workflows:\n  bad-wf:\n    steps:\n      - description: missing role\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	results, _ := validate.Run(dir)
+	cwResults := filterCustomWorkflowResults(results)
+	found := false
+	for _, r := range cwResults {
+		if !r.Passed && strings.Contains(r.Message, "role") { found = true }
+	}
+	if !found { t.Error("expected error for missing role") }
+}
+
+func TestRun_NoCustomWorkflowsSection(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+	cfg := "model:\n  provider: openai\n  name: gpt-4\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil { t.Fatal(err) }
+	results, _ := validate.Run(dir)
+	cwResults := filterCustomWorkflowResults(results)
+	if len(cwResults) != 0 { t.Errorf("got %d, want 0", len(cwResults)) }
 }

--- a/internal/workflow/custom_test.go
+++ b/internal/workflow/custom_test.go
@@ -1,0 +1,98 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joshluedeman/teamwork/internal/config"
+)
+
+func writeCustomConfig(t *testing.T, dir string) {
+	t.Helper()
+	twDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(twDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "model:\n  provider: \"openai\"\n  name: \"gpt-4\"\ncustom_workflows:\n  data-pipeline:\n    steps:\n      - role: \"planner\"\n        description: \"Design the data pipeline\"\n      - role: \"coder\"\n        description: \"Implement the pipeline\"\n      - role: \"tester\"\n        description: \"Verify pipeline output\"\n"
+	if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStartCustomWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	writeCustomConfig(t, dir)
+	eng, err := NewEngine(dir)
+	if err != nil { t.Fatal(err) }
+	ws, err := eng.Start("data-pipeline", "build pipeline", 42)
+	if err != nil { t.Fatalf("Start returned error: %v", err) }
+	if ws.Type != "data-pipeline" { t.Errorf("Type = %q, want data-pipeline", ws.Type) }
+	if ws.CurrentRole != "planner" { t.Errorf("CurrentRole = %q, want planner", ws.CurrentRole) }
+}
+
+func TestStartUnknownType(t *testing.T) {
+	dir := t.TempDir()
+	writeCustomConfig(t, dir)
+	eng, err := NewEngine(dir)
+	if err != nil { t.Fatal(err) }
+	_, err = eng.Start("does-not-exist", "goal", 1)
+	if err == nil { t.Fatal("expected error for unknown type") }
+}
+
+func TestBuiltinStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	writeCustomConfig(t, dir)
+	eng, err := NewEngine(dir)
+	if err != nil { t.Fatal(err) }
+	ws, err := eng.Start("feature", "new feature", 10)
+	if err != nil { t.Fatalf("Start returned error: %v", err) }
+	if ws.Type != "feature" { t.Errorf("Type = %q, want feature", ws.Type) }
+}
+
+func TestCustomDefinition(t *testing.T) {
+	cfg := &config.Config{
+		CustomWorkflows: map[string]config.CustomWorkflow{
+			"my-flow": {
+				Steps: []config.CustomStep{
+					{Role: "planner", Description: "plan it"},
+					{Role: "coder", Description: "code it"},
+				},
+			},
+		},
+	}
+	def, ok := CustomDefinition(cfg, "my-flow")
+	if !ok { t.Fatal("expected to find custom definition") }
+	if len(def.Steps) != 2 { t.Fatalf("Steps = %d, want 2", len(def.Steps)) }
+	if def.Steps[0].Role != "planner" { t.Errorf("Step 0 Role = %q, want planner", def.Steps[0].Role) }
+	_, ok = CustomDefinition(cfg, "missing")
+	if ok { t.Error("expected not found for missing type") }
+	_, ok = CustomDefinition(nil, "anything")
+	if ok { t.Error("expected not found for nil config") }
+}
+
+func TestIsBuiltinType(t *testing.T) {
+	if !IsBuiltinType("feature") { t.Error("feature should be builtin") }
+	if IsBuiltinType("my-custom") { t.Error("my-custom should not be builtin") }
+}
+
+func TestPreviewStepsWithConfig(t *testing.T) {
+	cfg := &config.Config{
+		CustomWorkflows: map[string]config.CustomWorkflow{
+			"my-flow": {
+				Steps: []config.CustomStep{
+					{Role: "planner", Description: "plan it"},
+					{Role: "coder", Description: "code it"},
+				},
+			},
+		},
+	}
+	steps, err := PreviewStepsWithConfig(cfg, "my-flow")
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if len(steps) != 2 { t.Fatalf("Steps = %d, want 2", len(steps)) }
+	steps, err = PreviewStepsWithConfig(cfg, "feature")
+	if err != nil { t.Fatalf("unexpected error for builtin: %v", err) }
+	if len(steps) == 0 { t.Error("expected steps for builtin type") }
+	_, err = PreviewStepsWithConfig(cfg, "nonexistent")
+	if err == nil { t.Error("expected error for unknown type") }
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -180,10 +180,47 @@ func NewEngine(dir string) (*Engine, error) {
 	return &Engine{Dir: dir, Config: cfg}, nil
 }
 
+// lookupDefinition returns the WorkflowDefinition for the given type,
+// checking built-in definitions first and then custom workflows from config.
+func (e *Engine) lookupDefinition(wfType string) (WorkflowDefinition, bool) {
+	if def, ok := definitions[wfType]; ok {
+		return def, true
+	}
+	return CustomDefinition(e.Config, wfType)
+}
+
+// CustomDefinition builds a WorkflowDefinition from a custom workflow in config.
+// It returns the definition and true if found, or a zero value and false otherwise.
+func CustomDefinition(cfg *config.Config, wfType string) (WorkflowDefinition, bool) {
+	if cfg == nil || cfg.CustomWorkflows == nil {
+		return WorkflowDefinition{}, false
+	}
+	cw, ok := cfg.CustomWorkflows[wfType]
+	if !ok || len(cw.Steps) == 0 {
+		return WorkflowDefinition{}, false
+	}
+	def := WorkflowDefinition{Type: wfType}
+	for i, s := range cw.Steps {
+		def.Steps = append(def.Steps, StepInfo{
+			Number: i + 1,
+			Role:   s.Role,
+			Action: s.Description,
+		})
+	}
+	return def, true
+}
+
+// IsBuiltinType reports whether the given type is a built-in workflow type.
+func IsBuiltinType(wfType string) bool {
+	_, ok := definitions[wfType]
+	return ok
+}
+
 // Start initializes a new workflow. It generates an ID from the workflow type,
 // issue number, and goal, creates the state file, and logs a start metric.
 func (e *Engine) Start(workflowType, goal string, issue int) (*state.WorkflowState, error) {
-	if _, ok := definitions[workflowType]; !ok {
+	def, ok := e.lookupDefinition(workflowType)
+	if !ok {
 		return nil, fmt.Errorf("workflow: unknown type %q", workflowType)
 	}
 
@@ -192,13 +229,13 @@ func (e *Engine) Start(workflowType, goal string, issue int) (*state.WorkflowSta
 	ws.Issue = issue
 	ws.Branch = id
 	ws.CurrentStep = 1
-	ws.CurrentRole = definitions[workflowType].Steps[0].Role
+	ws.CurrentRole = def.Steps[0].Role
 
 	// Record a StepRecord for step 1 so its start time is available later.
 	ws.Steps = append(ws.Steps, state.StepRecord{
 		Step:    1,
 		Role:    ws.CurrentRole,
-		Action:  definitions[workflowType].Steps[0].Action,
+		Action:  def.Steps[0].Action,
 		Started: ws.CreatedAt,
 	})
 
@@ -226,7 +263,7 @@ func (e *Engine) Next() ([]NextAction, error) {
 			continue
 		}
 
-		def, ok := definitions[ws.Type]
+		def, ok := e.lookupDefinition(ws.Type)
 		if !ok {
 			continue
 		}
@@ -312,7 +349,7 @@ func (e *Engine) Handoff(workflowID string, artifact *handoff.Artifact) error {
 	// Advance state to the next step.
 	nextRole := artifact.NextRole
 	nextAction := ""
-	def, ok := definitions[ws.Type]
+	def, ok := e.lookupDefinition(ws.Type)
 	if ok {
 		for _, s := range def.Steps {
 			if s.Number == ws.CurrentStep+1 {
@@ -409,7 +446,7 @@ func (e *Engine) Approve(workflowID string) error {
 	}
 
 	// Advance to next step if one exists.
-	def, ok := definitions[ws.Type]
+	def, ok := e.lookupDefinition(ws.Type)
 	if ok {
 		var next *StepInfo
 		for i := range def.Steps {
@@ -503,7 +540,7 @@ func (e *Engine) Complete(workflowID string) error {
 		return fmt.Errorf("workflow: load state: %w", err)
 	}
 
-	def, ok := definitions[ws.Type]
+	def, ok := e.lookupDefinition(ws.Type)
 	if ok {
 		totalSteps := len(def.Steps)
 		if ws.CurrentStep < totalSteps {

--- a/internal/workflow/preview.go
+++ b/internal/workflow/preview.go
@@ -1,6 +1,10 @@
 package workflow
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/joshluedeman/teamwork/internal/config"
+)
 
 // roleTier maps agent roles to their model tier (premium, standard, fast).
 // Human steps have no tier entry.
@@ -30,6 +34,21 @@ func PreviewSteps(workflowType string) ([]StepInfo, error) {
 		return nil, fmt.Errorf("workflow: unknown type %q", workflowType)
 	}
 	// Return a copy so callers cannot mutate the shared definitions.
+	steps := make([]StepInfo, len(def.Steps))
+	copy(steps, def.Steps)
+	return steps, nil
+}
+
+// PreviewStepsWithConfig returns step definitions for a workflow type,
+// checking both built-in and custom workflow definitions from config.
+func PreviewStepsWithConfig(cfg *config.Config, workflowType string) ([]StepInfo, error) {
+	def, ok := definitions[workflowType]
+	if !ok {
+		def, ok = CustomDefinition(cfg, workflowType)
+	}
+	if !ok {
+		return nil, fmt.Errorf("workflow: unknown type %q", workflowType)
+	}
 	steps := make([]StepInfo, len(def.Steps))
 	copy(steps, def.Steps)
 	return steps, nil


### PR DESCRIPTION
## Summary

Adds a `custom_workflows` section to `.teamwork/config.yaml` allowing users to define their own workflow types beyond the 10 built-in ones. Each custom workflow specifies a sequence of steps with role and description.

## Changes

### Config (`internal/config/config.go`)
- Added `CustomWorkflow` and `CustomStep` types
- Added `CustomWorkflows` map field to `Config` struct
- Added `HasCustomWorkflow(name)` method

### Engine (`internal/workflow/engine.go`)
- Added `lookupDefinition` method: checks built-in definitions first, falls back to custom
- Added `CustomDefinition` function: builds a `WorkflowDefinition` from config
- Added `IsBuiltinType` function: for use by the validate package
- Updated `Start`, `Next`, `Handoff`, `Approve`, `Complete` to use `lookupDefinition`

### Preview (`internal/workflow/preview.go`)
- Added `PreviewStepsWithConfig`: resolves both built-in and custom types
- Existing `PreviewSteps` preserved for backward compatibility

### Start Command (`cmd/teamwork/cmd/start.go`)
- Loads config early to check for custom workflow types
- Updated error message to mention custom workflows
- `runDryRun` uses `PreviewStepsWithConfig` for custom type support

### Validation (`internal/validate/validate.go`)
- Added `checkCustomWorkflows`: validates custom workflow definitions
  - Rejects names that conflict with built-in types
  - Requires at least one step per workflow
  - Requires `role` and `description` on each step

### Tests
- `internal/workflow/custom_test.go` (new): 6 tests for engine, definition, and preview
- `internal/config/config_test.go`: 4 new tests for loading and querying custom workflows
- `internal/validate/validate_test.go`: 5 new tests for validation rules

## Example Config

```yaml
custom_workflows:
  data-pipeline:
    steps:
      - role: planner
        description: Design the data pipeline
      - role: coder
        description: Implement the pipeline
      - role: tester
        description: Verify pipeline output
```

Fixes #120