### PR TITLE
feat(cli): add step-level retry and rollback commands

### DIFF
--- a/cmd/teamwork/cmd/retry.go
+++ b/cmd/teamwork/cmd/retry.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/joshluedeman/teamwork/internal/workflow"
+	"github.com/spf13/cobra"
+)
+
+var retryCmd = &cobra.Command{
+	Use:   "retry <workflow-id>",
+	Short: "Retry the current failed or blocked step of a workflow",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runRetry,
+}
+
+func init() {
+	rootCmd.AddCommand(retryCmd)
+}
+
+func runRetry(cmd *cobra.Command, args []string) error {
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return err
+	}
+
+	engine, err := workflow.NewEngine(dir)
+	if err != nil {
+		return err
+	}
+
+	if err := engine.Retry(args[0]); err != nil {
+		return err
+	}
+
+	fmt.Printf("Retrying workflow %s.\n", args[0])
+	return nil
+}

--- a/cmd/teamwork/cmd/rollback_step.go
+++ b/cmd/teamwork/cmd/rollback_step.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/joshluedeman/teamwork/internal/workflow"
+	"github.com/spf13/cobra"
+)
+
+var rollbackStepCmd = &cobra.Command{
+	Use:   "rollback-step <workflow-id>",
+	Short: "Roll back a workflow to its previous step",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runRollbackStep,
+}
+
+func init() {
+	rootCmd.AddCommand(rollbackStepCmd)
+}
+
+func runRollbackStep(cmd *cobra.Command, args []string) error {
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return err
+	}
+
+	engine, err := workflow.NewEngine(dir)
+	if err != nil {
+		return err
+	}
+
+	if err := engine.RollbackStep(args[0]); err != nil {
+		return err
+	}
+
+	fmt.Printf("Rolled back workflow %s to previous step.\n", args[0])
+	return nil
+}

--- a/internal/gates/gates.go
+++ b/internal/gates/gates.go
@@ -1,0 +1,55 @@
+package gates
+
+import (
+"fmt"
+"os/exec"
+)
+
+type Runner interface {
+Run(command, dir string) ([]byte, error)
+}
+
+type ShellRunner struct{}
+
+func (ShellRunner) Run(command, dir string) ([]byte, error) {
+cmd := exec.Command("/bin/sh", "-c", command)
+cmd.Dir = dir
+return cmd.CombinedOutput()
+}
+
+type GateResult struct {
+Condition string
+Output    string
+Passed    bool
+}
+
+func GateKey(step int) string {
+return fmt.Sprintf("after_step_%d", step)
+}
+
+func Lookup(extraGates map[string]map[string][]string, workflowType, location string) []string {
+if extraGates == nil {
+return nil
+}
+locs, ok := extraGates[workflowType]
+if !ok {
+return nil
+}
+return locs[location]
+}
+
+func RunGate(location string, conditions []string, dir string, runner Runner) ([]GateResult, bool, error) {
+var results []GateResult
+for _, cond := range conditions {
+out, err := runner.Run(cond, dir)
+if err != nil {
+if _, ok := err.(*exec.ExitError); ok {
+results = append(results, GateResult{Condition: cond, Output: string(out), Passed: false})
+return results, false, nil
+}
+return results, false, fmt.Errorf("gates: run %q: %w", cond, err)
+}
+results = append(results, GateResult{Condition: cond, Output: string(out), Passed: true})
+}
+return results, true, nil
+}

--- a/internal/gates/gates_test.go
+++ b/internal/gates/gates_test.go
@@ -1,0 +1,87 @@
+package gates
+
+import (
+"fmt"
+"os/exec"
+"testing"
+)
+
+type mockRunner struct {
+calls   []string
+outputs []string
+errs    []error
+idx     int
+}
+
+func (m *mockRunner) Run(command, dir string) ([]byte, error) {
+m.calls = append(m.calls, command)
+i := m.idx
+m.idx++
+var out string
+if i < len(m.outputs) {
+out = m.outputs[i]
+}
+if i < len(m.errs) && m.errs[i] != nil {
+return []byte(out), m.errs[i]
+}
+return []byte(out), nil
+}
+
+func TestRunGateAllPass(t *testing.T) {
+m := &mockRunner{outputs: []string{"ok1", "ok2"}, errs: []error{nil, nil}}
+results, passed, err := RunGate("after_step_1", []string{"cmd1", "cmd2"}, "/tmp", m)
+if err != nil { t.Fatalf("unexpected: %v", err) }
+if !passed { t.Fatal("expected pass") }
+if len(results) != 2 { t.Fatalf("got %d", len(results)) }
+if len(m.calls) != 2 { t.Fatalf("got %d calls", len(m.calls)) }
+}
+
+func TestRunGateFirstFails(t *testing.T) {
+m := &mockRunner{outputs: []string{"fail"}, errs: []error{&exec.ExitError{}}}
+results, passed, err := RunGate("after_step_1", []string{"bad", "good"}, "/tmp", m)
+if err != nil { t.Fatalf("unexpected: %v", err) }
+if passed { t.Fatal("expected failure") }
+if len(results) != 1 { t.Fatalf("got %d", len(results)) }
+if len(m.calls) != 1 { t.Fatalf("got %d calls", len(m.calls)) }
+}
+
+func TestRunGateSecondFails(t *testing.T) {
+m := &mockRunner{outputs: []string{"ok", "fail"}, errs: []error{nil, &exec.ExitError{}}}
+_, passed, err := RunGate("after_step_1", []string{"good", "bad"}, "/tmp", m)
+if err != nil { t.Fatalf("unexpected: %v", err) }
+if passed { t.Fatal("expected failure") }
+}
+
+func TestRunGateEmptyConditions(t *testing.T) {
+m := &mockRunner{}
+results, passed, err := RunGate("after_step_1", []string{}, "/tmp", m)
+if err != nil { t.Fatalf("unexpected: %v", err) }
+if !passed { t.Fatal("should pass") }
+if len(results) != 0 { t.Fatalf("got %d", len(results)) }
+}
+
+func TestGateKey(t *testing.T) {
+if got := GateKey(1); got != "after_step_1" { t.Errorf("got %q", got) }
+if got := GateKey(3); got != "after_step_3" { t.Errorf("got %q", got) }
+}
+
+func TestLookup(t *testing.T) {
+g := map[string]map[string][]string{"feature": {"after_step_2": {"lint", "test"}}}
+if got := Lookup(g, "feature", "after_step_2"); len(got) != 2 { t.Fatalf("got %v", got) }
+if Lookup(g, "bugfix", "after_step_2") != nil { t.Fatal("wrong type") }
+if Lookup(g, "feature", "after_step_1") != nil { t.Fatal("wrong loc") }
+if Lookup(nil, "feature", "after_step_2") != nil { t.Fatal("nil") }
+}
+
+func TestShellRunnerIntegration(t *testing.T) {
+r := ShellRunner{}
+out, err := r.Run("echo hello", t.TempDir())
+if err != nil { t.Fatalf("unexpected: %v", err) }
+if string(out) != "hello\n" { t.Errorf("got %q", string(out)) }
+_, err = r.Run("exit 1", t.TempDir())
+if err == nil { t.Fatal("expected error") }
+if _, ok := err.(*exec.ExitError); !ok { t.Fatalf("got %T", err) }
+out, err = r.Run(fmt.Sprintf("echo fail && exit 1"), t.TempDir())
+if err == nil { t.Fatal("expected error") }
+if string(out) != "fail\n" { t.Errorf("got %q", string(out)) }
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,6 +27,8 @@ const (
 	ActionUnblock     = "unblock"
 	ActionDefect      = "defect"
 	ActionCancel      = "cancel"
+	ActionRetry       = "retry"
+	ActionRollback    = "rollback"
 )
 
 // Event represents a single metrics entry logged during workflow execution.
@@ -131,6 +133,26 @@ func LogGate(dir, workflowID string, step int, role, detail, result string) erro
 		Action: ActionQualityGate,
 		Detail: detail,
 		Result: result,
+	})
+}
+
+// LogRetry logs a retry event for the given workflow step.
+func LogRetry(dir, workflowID string, step int, role, detail string) error {
+	return Log(dir, workflowID, Event{
+		Step:   step,
+		Role:   role,
+		Action: ActionRetry,
+		Detail: detail,
+	})
+}
+
+// LogRollback logs a rollback event when reverting to a previous step.
+func LogRollback(dir, workflowID string, fromStep, toStep int, role, detail string) error {
+	return Log(dir, workflowID, Event{
+		Step:   toStep,
+		Role:   role,
+		Action: ActionRollback,
+		Detail: detail,
 	})
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/joshluedeman/teamwork/internal/config"
+	"github.com/joshluedeman/teamwork/internal/gates"
 	"github.com/joshluedeman/teamwork/internal/handoff"
 	"github.com/joshluedeman/teamwork/internal/metrics"
 	"github.com/joshluedeman/teamwork/internal/state"
@@ -18,8 +19,9 @@ import (
 
 // Engine manages workflow execution by coordinating state, handoffs, and metrics.
 type Engine struct {
-	Dir    string         // project root directory
-	Config *config.Config // parsed .teamwork/config.yaml
+	Dir        string         // project root directory
+	Config     *config.Config // parsed .teamwork/config.yaml
+	GateRunner gates.Runner   // optional runner for extra quality gates
 }
 
 // StepInfo describes a single step within a workflow definition.
@@ -310,8 +312,9 @@ func (e *Engine) Next() ([]NextAction, error) {
 	return actions, nil
 }
 
-// Handoff validates a handoff artifact, saves it, advances the workflow state,
-// and logs completion and start metrics for the transition.
+// Handoff validates a handoff artifact, saves it, runs any extra quality gates,
+// advances the workflow state, and logs completion and start metrics for the
+// transition.
 func (e *Engine) Handoff(workflowID string, artifact *handoff.Artifact) error {
 	if errs := handoff.Validate(artifact); errs != nil {
 		return fmt.Errorf("workflow: invalid handoff: %s", strings.Join(errs, "; "))
@@ -339,6 +342,21 @@ func (e *Engine) Handoff(workflowID string, artifact *handoff.Artifact) error {
 	var durationSec int
 	if startedAt, err := ws.CurrentStepStartedAt(); err == nil {
 		durationSec = int(time.Since(startedAt).Seconds())
+	}
+
+	// Run extra quality gates if configured.
+	if e.GateRunner != nil && e.Config != nil {
+		location := gates.GateKey(ws.CurrentStep)
+		conditions := gates.Lookup(e.Config.Workflows.ExtraGates, ws.Type, location)
+		if len(conditions) > 0 {
+			_, passed, err := gates.RunGate(location, conditions, e.Dir, e.GateRunner)
+			if err != nil {
+				return fmt.Errorf("workflow: run extra gate: %w", err)
+			}
+			if !passed {
+				return fmt.Errorf("workflow: extra gate failed at %s", location)
+			}
+		}
 	}
 
 	// Log completion of the current step.
@@ -616,6 +634,104 @@ func (e *Engine) Fail(workflowID, reason string) error {
 
 	if err := metrics.LogFail(e.Dir, workflowID, ws.CurrentStep, ws.CurrentRole, reason, reason); err != nil {
 		return fmt.Errorf("workflow: log fail: %w", err)
+	}
+
+	return nil
+}
+
+// Retry resets the current failed or blocked step so it can be re-run.
+// It clears the step's completion timestamp, quality gate, and any blockers,
+// then sets the workflow back to active.
+func (e *Engine) Retry(workflowID string) error {
+	ws, err := state.Load(e.Dir, workflowID)
+	if err != nil {
+		return fmt.Errorf("workflow: load state: %w", err)
+	}
+
+	if ws.Status != state.StatusFailed && ws.Status != state.StatusBlocked {
+		return fmt.Errorf("workflow: cannot retry: workflow %q is %s, not failed or blocked", workflowID, ws.Status)
+	}
+
+	// Reset the current step record so it can be re-executed.
+	for i := range ws.Steps {
+		if ws.Steps[i].Step == ws.CurrentStep {
+			ws.Steps[i].Completed = ""
+			ws.Steps[i].QualityGate = ""
+		}
+	}
+
+	ws.Status = state.StatusActive
+	ws.Blockers = nil
+	ws.UpdatedAt = ""
+
+	if err := ws.Save(e.Dir); err != nil {
+		return fmt.Errorf("workflow: save state: %w", err)
+	}
+
+	if err := metrics.LogRetry(e.Dir, workflowID, ws.CurrentStep, ws.CurrentRole, "Retrying step"); err != nil {
+		return fmt.Errorf("workflow: log retry: %w", err)
+	}
+
+	return nil
+}
+
+// RollbackStep reverts the workflow to the previous step. It removes the
+// current step record, decrements the step counter, and sets the workflow
+// back to active. Rollback from step 1 is not allowed.
+func (e *Engine) RollbackStep(workflowID string) error {
+	ws, err := state.Load(e.Dir, workflowID)
+	if err != nil {
+		return fmt.Errorf("workflow: load state: %w", err)
+	}
+
+	if ws.Status == state.StatusCompleted || ws.Status == state.StatusCancelled {
+		return fmt.Errorf("workflow: cannot rollback: workflow %q is %s", workflowID, ws.Status)
+	}
+
+	if ws.CurrentStep <= 1 {
+		return fmt.Errorf("workflow: cannot rollback: workflow %q is already at step 1", workflowID)
+	}
+
+	fromStep := ws.CurrentStep
+
+	// Remove step records for the current step.
+	var kept []state.StepRecord
+	for _, sr := range ws.Steps {
+		if sr.Step != ws.CurrentStep {
+			kept = append(kept, sr)
+		}
+	}
+	ws.Steps = kept
+
+	// Move to the previous step and reset its completion status.
+	ws.CurrentStep = fromStep - 1
+	for i := range ws.Steps {
+		if ws.Steps[i].Step == ws.CurrentStep {
+			ws.Steps[i].Completed = ""
+			ws.Steps[i].QualityGate = ""
+		}
+	}
+
+	// Resolve the role from the workflow definition.
+	def, ok := definitions[ws.Type]
+	if ok {
+		for _, s := range def.Steps {
+			if s.Number == ws.CurrentStep {
+				ws.CurrentRole = s.Role
+				break
+			}
+		}
+	}
+
+	ws.Status = state.StatusActive
+	ws.Blockers = nil
+
+	if err := ws.Save(e.Dir); err != nil {
+		return fmt.Errorf("workflow: save state: %w", err)
+	}
+
+	if err := metrics.LogRollback(e.Dir, workflowID, fromStep, ws.CurrentStep, ws.CurrentRole, "Rolled back step"); err != nil {
+		return fmt.Errorf("workflow: log rollback: %w", err)
 	}
 
 	return nil

--- a/internal/workflow/engine_gates_test.go
+++ b/internal/workflow/engine_gates_test.go
@@ -1,0 +1,138 @@
+package workflow
+
+import (
+"os"
+"os/exec"
+"path/filepath"
+"strings"
+"testing"
+"time"
+
+"github.com/joshluedeman/teamwork/internal/config"
+"github.com/joshluedeman/teamwork/internal/gates"
+"github.com/joshluedeman/teamwork/internal/handoff"
+"github.com/joshluedeman/teamwork/internal/state"
+)
+
+func realExitError() *exec.ExitError {
+err := exec.Command("/bin/sh", "-c", "exit 1").Run()
+ee, _ := err.(*exec.ExitError)
+return ee
+}
+
+type mockGateRunner struct {
+calls   []string
+outputs []string
+errs    []error
+idx     int
+}
+
+func (m *mockGateRunner) Run(command, dir string) ([]byte, error) {
+m.calls = append(m.calls, command)
+i := m.idx
+m.idx++
+var out string
+if i < len(m.outputs) {
+out = m.outputs[i]
+}
+if i < len(m.errs) && m.errs[i] != nil {
+return []byte(out), m.errs[i]
+}
+return []byte(out), nil
+}
+
+func setupEngineWithGates(t *testing.T, extraGates map[string]map[string][]string, runner gates.Runner) (*Engine, string) {
+t.Helper()
+dir := t.TempDir()
+twDir := filepath.Join(dir, ".teamwork")
+if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
+cfgYAML := "project_name: test\nworkflows:\n  extra_gates: {}\n"
+if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfgYAML), 0o644); err != nil { t.Fatal(err) }
+if err := os.MkdirAll(filepath.Join(twDir, "metrics"), 0o755); err != nil { t.Fatal(err) }
+if err := os.MkdirAll(filepath.Join(twDir, "handoffs"), 0o755); err != nil { t.Fatal(err) }
+cfg, err := config.Load(dir)
+if err != nil { t.Fatal(err) }
+cfg.Workflows.ExtraGates = extraGates
+return &Engine{Dir: dir, Config: cfg, GateRunner: runner}, dir
+}
+
+func makeTestArtifact(wfID string, step int, role, nextRole string) *handoff.Artifact {
+return &handoff.Artifact{
+WorkflowID: wfID, Step: step, Role: role, NextRole: nextRole,
+Date: time.Now().Format(time.RFC3339), Summary: "test", Context: "ctx",
+}
+}
+
+func createTestWorkflow(t *testing.T, dir, wfID, wfType string, step int, role string) {
+t.Helper()
+ws := &state.WorkflowState{
+ID: wfID, Type: wfType, Status: state.StatusActive,
+CurrentStep: step, CurrentRole: role, Goal: "test", Branch: wfID,
+Steps: []state.StepRecord{{Step: step, Role: role, Started: time.Now().Format(time.RFC3339)}},
+}
+if err := ws.Save(dir); err != nil { t.Fatal(err) }
+}
+
+func TestExtraGatesPass(t *testing.T) {
+r := &mockGateRunner{outputs: []string{"ok1", "ok2"}, errs: []error{nil, nil}}
+eg := map[string]map[string][]string{"feature": {"after_step_1": {"lint", "test"}}}
+e, dir := setupEngineWithGates(t, eg, r)
+createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
+err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
+if err != nil { t.Fatalf("expected success: %v", err) }
+if len(r.calls) != 2 { t.Fatalf("expected 2 calls, got %d", len(r.calls)) }
+ws, _ := state.Load(dir, "feature-42-x")
+if ws.CurrentStep != 2 { t.Fatalf("expected step 2, got %d", ws.CurrentStep) }
+}
+
+func TestExtraGatesFail(t *testing.T) {
+r := &mockGateRunner{outputs: []string{"ok", "FAIL"}, errs: []error{nil, realExitError()}}
+eg := map[string]map[string][]string{"feature": {"after_step_1": {"lint", "test"}}}
+e, dir := setupEngineWithGates(t, eg, r)
+createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
+err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
+if err == nil { t.Fatal("expected error") }
+if !strings.Contains(err.Error(), "extra gate") { t.Fatalf("wrong error: %v", err) }
+ws, _ := state.Load(dir, "feature-42-x")
+if ws.CurrentStep != 1 { t.Fatalf("expected step 1, got %d", ws.CurrentStep) }
+}
+
+func TestExtraGatesNoGatesConfigured(t *testing.T) {
+r := &mockGateRunner{}
+e, dir := setupEngineWithGates(t, nil, r)
+createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
+err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
+if err != nil { t.Fatalf("expected success: %v", err) }
+if len(r.calls) != 0 { t.Fatalf("expected 0 calls, got %d", len(r.calls)) }
+}
+
+func TestExtraGatesWrongStep(t *testing.T) {
+r := &mockGateRunner{}
+eg := map[string]map[string][]string{"feature": {"after_step_2": {"no"}}}
+e, dir := setupEngineWithGates(t, eg, r)
+createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
+err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
+if err != nil { t.Fatalf("expected success: %v", err) }
+if len(r.calls) != 0 { t.Fatalf("expected 0 calls, got %d", len(r.calls)) }
+}
+
+func TestExtraGatesWrongWorkflowType(t *testing.T) {
+r := &mockGateRunner{}
+eg := map[string]map[string][]string{"bugfix": {"after_step_1": {"no"}}}
+e, dir := setupEngineWithGates(t, eg, r)
+createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
+err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
+if err != nil { t.Fatalf("expected success: %v", err) }
+if len(r.calls) != 0 { t.Fatalf("expected 0 calls, got %d", len(r.calls)) }
+}
+
+func TestExtraGatesFirstCommandFails(t *testing.T) {
+r := &mockGateRunner{outputs: []string{"FAIL"}, errs: []error{realExitError()}}
+eg := map[string]map[string][]string{"feature": {"after_step_1": {"bad", "good"}}}
+e, dir := setupEngineWithGates(t, eg, r)
+createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
+err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
+if err == nil { t.Fatal("expected error") }
+if len(r.calls) != 1 { t.Fatalf("expected 1 call, got %d", len(r.calls)) }
+if r.calls[0] != "bad" { t.Fatalf("expected bad, got %q", r.calls[0]) }
+}

--- a/internal/workflow/engine_retry_rollback_test.go
+++ b/internal/workflow/engine_retry_rollback_test.go
@@ -1,0 +1,288 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joshluedeman/teamwork/internal/state"
+)
+
+// createWorkflowInState creates a workflow state file with the given status.
+func createWorkflowInState(t *testing.T, dir, wfID, wfType, status string, step int, role string) {
+	t.Helper()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	ws := &state.WorkflowState{
+		ID:          wfID,
+		Type:        wfType,
+		Status:      status,
+		CurrentStep: step,
+		CurrentRole: role,
+		Goal:        "test goal",
+		Branch:      wfID,
+		CreatedAt:   ts,
+		UpdatedAt:   ts,
+		Steps:       []state.StepRecord{{Step: step, Role: role, Started: ts}},
+	}
+	if status == state.StatusFailed {
+		ws.Steps[0].Completed = ts
+		ws.Steps[0].QualityGate = "failed"
+		ws.Blockers = []state.Blocker{{Reason: "test failure", RaisedBy: role, RaisedAt: ts}}
+	}
+	if status == state.StatusBlocked {
+		ws.Blockers = []state.Blocker{{Reason: "blocked reason", RaisedBy: "human", RaisedAt: ts}}
+	}
+	if err := ws.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// createMultiStepWorkflow creates a workflow at a given step with step records for all prior steps.
+func createMultiStepWorkflow(t *testing.T, dir, wfID, wfType, status string, currentStep int) {
+	t.Helper()
+	ts := time.Now().UTC().Format(time.RFC3339)
+
+	var steps []state.StepRecord
+	for s := 1; s < currentStep; s++ {
+		steps = append(steps, state.StepRecord{
+			Step:      s,
+			Role:      "test-role",
+			Action:    "test action",
+			Started:   ts,
+			Completed: ts,
+		})
+	}
+	// Current step (not completed).
+	steps = append(steps, state.StepRecord{
+		Step:    currentStep,
+		Role:    "coder",
+		Action:  "current action",
+		Started: ts,
+	})
+
+	ws := &state.WorkflowState{
+		ID:          wfID,
+		Type:        wfType,
+		Status:      status,
+		CurrentStep: currentStep,
+		CurrentRole: "coder",
+		Goal:        "test goal",
+		Branch:      wfID,
+		CreatedAt:   ts,
+		UpdatedAt:   ts,
+		Steps:       steps,
+	}
+	if status == state.StatusFailed {
+		ws.Steps[len(ws.Steps)-1].Completed = ts
+		ws.Steps[len(ws.Steps)-1].QualityGate = "failed"
+		ws.Blockers = []state.Blocker{{Reason: "test failure", RaisedBy: "coder", RaisedAt: ts}}
+	}
+	if err := ws.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// --- Retry tests ---
+
+func TestRetryFromFailed(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createWorkflowInState(t, dir, "feature/42-test", "feature", state.StatusFailed, 3, "architect")
+
+	if err := e.Retry("feature/42-test"); err != nil {
+		t.Fatalf("Retry failed: %v", err)
+	}
+
+	ws, err := state.Load(dir, "feature/42-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.Status != state.StatusActive {
+		t.Errorf("expected status active, got %s", ws.Status)
+	}
+	if ws.CurrentStep != 3 {
+		t.Errorf("expected step 3, got %d", ws.CurrentStep)
+	}
+	if len(ws.Blockers) != 0 {
+		t.Errorf("expected no blockers, got %d", len(ws.Blockers))
+	}
+	// Step record should have cleared completed and quality_gate.
+	for _, sr := range ws.Steps {
+		if sr.Step == 3 {
+			if sr.Completed != "" {
+				t.Errorf("expected cleared completed, got %q", sr.Completed)
+			}
+			if sr.QualityGate != "" {
+				t.Errorf("expected cleared quality_gate, got %q", sr.QualityGate)
+			}
+		}
+	}
+}
+
+func TestRetryFromBlocked(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createWorkflowInState(t, dir, "feature/43-test", "feature", state.StatusBlocked, 2, "planner")
+
+	if err := e.Retry("feature/43-test"); err != nil {
+		t.Fatalf("Retry failed: %v", err)
+	}
+
+	ws, err := state.Load(dir, "feature/43-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.Status != state.StatusActive {
+		t.Errorf("expected status active, got %s", ws.Status)
+	}
+	if len(ws.Blockers) != 0 {
+		t.Errorf("expected no blockers, got %d", len(ws.Blockers))
+	}
+}
+
+func TestRetryFromActiveErrors(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createWorkflowInState(t, dir, "feature/44-test", "feature", state.StatusActive, 2, "planner")
+
+	err := e.Retry("feature/44-test")
+	if err == nil {
+		t.Fatal("expected error retrying active workflow")
+	}
+	if got := err.Error(); !contains(got, "not failed or blocked") {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestRetryFromCompletedErrors(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createWorkflowInState(t, dir, "feature/45-test", "feature", state.StatusCompleted, 9, "documenter")
+
+	err := e.Retry("feature/45-test")
+	if err == nil {
+		t.Fatal("expected error retrying completed workflow")
+	}
+	if got := err.Error(); !contains(got, "not failed or blocked") {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+// --- RollbackStep tests ---
+
+func TestRollbackStepFromStep2(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createMultiStepWorkflow(t, dir, "feature/50-test", "feature", state.StatusFailed, 2)
+
+	if err := e.RollbackStep("feature/50-test"); err != nil {
+		t.Fatalf("RollbackStep failed: %v", err)
+	}
+
+	ws, err := state.Load(dir, "feature/50-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.Status != state.StatusActive {
+		t.Errorf("expected status active, got %s", ws.Status)
+	}
+	if ws.CurrentStep != 1 {
+		t.Errorf("expected step 1, got %d", ws.CurrentStep)
+	}
+	if ws.CurrentRole != "human" {
+		t.Errorf("expected role human (feature step 1), got %s", ws.CurrentRole)
+	}
+	// Step 2 records should be removed.
+	for _, sr := range ws.Steps {
+		if sr.Step == 2 {
+			t.Error("step 2 record should have been removed")
+		}
+	}
+	// Step 1 should have cleared completed status.
+	for _, sr := range ws.Steps {
+		if sr.Step == 1 && sr.Completed != "" {
+			t.Errorf("step 1 completed should be cleared, got %q", sr.Completed)
+		}
+	}
+}
+
+func TestRollbackStepFromStep1Errors(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createWorkflowInState(t, dir, "feature/51-test", "feature", state.StatusFailed, 1, "human")
+
+	err := e.RollbackStep("feature/51-test")
+	if err == nil {
+		t.Fatal("expected error rolling back from step 1")
+	}
+	if got := err.Error(); !contains(got, "already at step 1") {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestRollbackStepFromCompletedErrors(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createWorkflowInState(t, dir, "feature/52-test", "feature", state.StatusCompleted, 9, "documenter")
+
+	err := e.RollbackStep("feature/52-test")
+	if err == nil {
+		t.Fatal("expected error rolling back completed workflow")
+	}
+	if got := err.Error(); !contains(got, "cannot rollback") {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestRollbackStepFromActiveAtStep3(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createMultiStepWorkflow(t, dir, "feature/53-test", "feature", state.StatusActive, 3)
+
+	if err := e.RollbackStep("feature/53-test"); err != nil {
+		t.Fatalf("RollbackStep failed: %v", err)
+	}
+
+	ws, err := state.Load(dir, "feature/53-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.CurrentStep != 2 {
+		t.Errorf("expected step 2, got %d", ws.CurrentStep)
+	}
+	if ws.CurrentRole != "planner" {
+		t.Errorf("expected role planner (feature step 2), got %s", ws.CurrentRole)
+	}
+}
+
+func TestRollbackStepClearsBlockers(t *testing.T) {
+	e, dir := setupTestEngine(t)
+	createMultiStepWorkflow(t, dir, "feature/54-test", "feature", state.StatusBlocked, 4)
+	// Manually add a blocker.
+	ws, _ := state.Load(dir, "feature/54-test")
+	ws.Status = state.StatusBlocked
+	ws.Blockers = []state.Blocker{{Reason: "blocked", RaisedBy: "human", RaisedAt: time.Now().UTC().Format(time.RFC3339)}}
+	if err := ws.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.RollbackStep("feature/54-test"); err != nil {
+		t.Fatalf("RollbackStep failed: %v", err)
+	}
+
+	ws, err := state.Load(dir, "feature/54-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.Status != state.StatusActive {
+		t.Errorf("expected status active, got %s", ws.Status)
+	}
+	if len(ws.Blockers) != 0 {
+		t.Errorf("expected no blockers, got %d", len(ws.Blockers))
+	}
+}
+
+// contains checks if s contains substr.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && containsHelper(s, substr)
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds two new CLI commands for step-level workflow recovery:

- **`teamwork retry <workflow-id>`** — Re-runs the current failed or blocked step by resetting its status, clearing errors/blockers, and setting the workflow back to active.
- **`teamwork rollback-step <workflow-id>`** — Reverts the workflow to the previous step by removing the current step record, decrementing the step counter, and resolving the role from the workflow definition. Rollback from step 1 is prevented.

## Changes

### New files
- `cmd/teamwork/cmd/retry.go` — CLI command for `teamwork retry`
- `cmd/teamwork/cmd/rollback_step.go` — CLI command for `teamwork rollback-step`
- `internal/workflow/engine_retry_rollback_test.go` — 9 test cases covering retry/rollback behavior and error cases

### Modified files
- `internal/workflow/engine.go` — Added `Retry()` and `RollbackStep()` methods; added `GateRunner` field and extra gate logic in `Handoff()`
- `internal/metrics/metrics.go` — Added `ActionRetry`/`ActionRollback` constants and `LogRetry()`/`LogRollback()` helpers

### Also included (previously untracked)
- `internal/gates/` — Quality gate runner package (was on disk but untracked)
- `internal/workflow/engine_gates_test.go` — Tests for extra gates in Handoff

## Test coverage
- Retry from failed state ✓
- Retry from blocked state ✓
- Retry from active/completed errors ✓
- Rollback from step 2 → 1 ✓
- Rollback from step 3 → 2 ✓
- Prevent rollback from step 1 ✓
- Prevent rollback from completed workflow ✓
- Rollback clears blockers ✓

Fixes #114