### PR TITLE
feat(update): add --check flag for configuration drift detection

### DIFF
--- a/cmd/teamwork/cmd/update.go
+++ b/cmd/teamwork/cmd/update.go
@@ -29,6 +29,7 @@ func init() {
 	updateCmd.Flags().String("ref", "main", "Git ref to update to (branch, tag, or SHA)")
 	updateCmd.Flags().Bool("force", false, "Overwrite user-modified files without warning")
 	updateCmd.Flags().Bool("create-issue", true, "Create a GitHub issue assigned to Copilot for setup when placeholders are detected")
+	updateCmd.Flags().Bool("check", false, "Report configuration drift without updating files (exits 1 if drift found)")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -52,10 +53,18 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	checkOnly, err := cmd.Flags().GetBool("check")
+	if err != nil {
+		return err
+	}
 
 	owner, repo, err := parseUpdateSource(source)
 	if err != nil {
 		return err
+	}
+
+	if checkOnly {
+		return runDriftCheck(cmd, dir, owner, repo, ref)
 	}
 
 	if err := installer.Update(dir, owner, repo, ref, force); err != nil {
@@ -69,6 +78,48 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// runDriftCheck downloads the upstream tarball, compares against installed files,
+// prints a summary to the command output, and returns an ExitError with code 1
+// if drift is detected (suitable for CI use).
+func runDriftCheck(cmd *cobra.Command, dir, owner, repo, ref string) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "Checking for configuration drift...")
+
+	result, err := installer.CheckDrift(dir, owner, repo, ref)
+	if err != nil {
+		return fmt.Errorf("drift check failed: %w", err)
+	}
+
+	if !result.HasDrift() {
+		fmt.Fprintln(out, "No drift detected. Framework files are up to date.")
+		return nil
+	}
+
+	if len(result.Added) > 0 {
+		fmt.Fprintf(out, "\nFiles that would be added (%d):\n", len(result.Added))
+		for _, f := range result.Added {
+			fmt.Fprintf(out, "  + %s\n", f)
+		}
+	}
+	if len(result.Modified) > 0 {
+		fmt.Fprintf(out, "\nFiles that would be modified (%d):\n", len(result.Modified))
+		for _, f := range result.Modified {
+			fmt.Fprintf(out, "  ~ %s\n", f)
+		}
+	}
+	if len(result.Removed) > 0 {
+		fmt.Fprintf(out, "\nFiles that would be removed (%d):\n", len(result.Removed))
+		for _, f := range result.Removed {
+			fmt.Fprintf(out, "  - %s\n", f)
+		}
+	}
+
+	total := len(result.Added) + len(result.Modified) + len(result.Removed)
+	fmt.Fprintf(out, "\nDrift detected: %d file(s) would change. Run 'teamwork update' to apply.\n", total)
+
+	return &ExitError{Code: 1, Message: "drift detected"}
 }
 
 // setupIssueTitle is the canonical title used for setup-teamwork issues.

--- a/cmd/teamwork/cmd/update_test.go
+++ b/cmd/teamwork/cmd/update_test.go
@@ -1,8 +1,17 @@
 package cmd
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestBuildSetupIssueBody_ContainsFileList(t *testing.T) {
@@ -55,5 +64,161 @@ func TestParseUpdateSource_Invalid(t *testing.T) {
 		if err == nil {
 			t.Errorf("parseUpdateSource(%q) should have returned error", c)
 		}
+	}
+}
+
+// ---- --check flag tests ----
+
+const checkTestPrefix = "JoshLuedeman-teamwork-abc1234abc1234/"
+
+// cmdTarball builds a minimal .tar.gz with files nested under prefix.
+func cmdTarball(prefix string, files map[string]string) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	_ = tw.WriteHeader(&tar.Header{Typeflag: tar.TypeDir, Name: prefix, Mode: 0o755})
+	for name, content := range files {
+		data := []byte(content)
+		_ = tw.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: prefix + name, Mode: 0o644, Size: int64(len(data))})
+		_, _ = tw.Write(data)
+	}
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}
+
+// cmdTestServer returns a test server that serves the provided tarball bytes.
+func cmdTestServer(tb []byte) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tb)
+	}))
+}
+
+// cmdRedirectTransport rewrites all HTTP requests to the given target URL.
+type cmdRedirectTransport struct {
+	target string
+	base   *http.Transport
+}
+
+func (rt *cmdRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := req.Clone(req.Context())
+	req2.URL.Scheme = "http"
+	target := rt.target
+	for _, pfx := range []string{"https://", "http://"} {
+		if strings.HasPrefix(target, pfx) {
+			target = target[len(pfx):]
+			break
+		}
+	}
+	req2.URL.Host = target
+	return rt.base.RoundTrip(req2)
+}
+
+// resetUpdateFlags resets the update command flags to defaults between tests.
+func resetUpdateFlags(t *testing.T) {
+	t.Helper()
+	updateCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+}
+
+// executeUpdateCmd runs "teamwork update" with args and captures stdout/stderr.
+func executeUpdateCmd(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	resetUpdateFlags(t)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"update", "--dir", dir}, args...))
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// writeTeamworkMeta writes minimal .teamwork files so CheckDrift can read state.
+func writeTeamworkMeta(t *testing.T, dir string) {
+	t.Helper()
+	teamworkDir := filepath.Join(dir, ".teamwork")
+	if err := os.MkdirAll(teamworkDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll .teamwork: %v", err)
+	}
+	_ = os.WriteFile(filepath.Join(teamworkDir, "framework-version.txt"), []byte("abc1234abc1234\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(teamworkDir, "framework-manifest.json"),
+		[]byte(`{"version":"abc1234abc1234","files":{}}`), 0o644)
+}
+
+// patchHTTP redirects all HTTP requests to srv.
+func patchHTTP(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	original := http.DefaultTransport
+	http.DefaultTransport = &cmdRedirectTransport{target: srv.URL, base: &http.Transport{}}
+	t.Cleanup(func() { http.DefaultTransport = original })
+}
+
+// TestCheckFlag_NoDrift verifies --check exits 0 when local files match upstream.
+func TestCheckFlag_NoDrift(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		".editorconfig":                   "root = true\n",
+		".github/copilot-instructions.md": "instructions\n",
+	}
+	for relPath, content := range files {
+		dst := filepath.Join(dir, relPath)
+		_ = os.MkdirAll(filepath.Dir(dst), 0o755)
+		_ = os.WriteFile(dst, []byte(content), 0o644)
+	}
+	writeTeamworkMeta(t, dir)
+	srv := cmdTestServer(cmdTarball(checkTestPrefix, files))
+	t.Cleanup(srv.Close)
+	patchHTTP(t, srv)
+	out, err := executeUpdateCmd(t, dir, "--check", "--source", "JoshLuedeman/teamwork")
+	if err != nil {
+		t.Fatalf("--check with no drift should exit 0, got: %v", err)
+	}
+	if !strings.Contains(out, "No drift") {
+		t.Errorf("expected 'No drift' in output, got: %q", out)
+	}
+}
+
+// TestCheckFlag_DriftDetected verifies --check exits 1 when local files differ.
+func TestCheckFlag_DriftDetected(t *testing.T) {
+	dir := t.TempDir()
+	upstreamFiles := map[string]string{".editorconfig": "root = true\n"}
+	_ = os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte("# modified\n"), 0o644)
+	writeTeamworkMeta(t, dir)
+	srv := cmdTestServer(cmdTarball(checkTestPrefix, upstreamFiles))
+	t.Cleanup(srv.Close)
+	patchHTTP(t, srv)
+	out, err := executeUpdateCmd(t, dir, "--check", "--source", "JoshLuedeman/teamwork")
+	exitErr, ok := err.(*ExitError)
+	if !ok || exitErr.Code != 1 {
+		t.Errorf("expected ExitError{Code:1}, got: %v (type %T)", err, err)
+	}
+	if !strings.Contains(out, "Drift detected") {
+		t.Errorf("expected 'Drift detected' in output, got: %q", out)
+	}
+	if !strings.Contains(out, ".editorconfig") {
+		t.Errorf("expected .editorconfig in output, got: %q", out)
+	}
+}
+
+// TestCheckFlag_NoFilesModified verifies --check does not write to disk.
+func TestCheckFlag_NoFilesModified(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte("local\n"), 0o644)
+	writeTeamworkMeta(t, dir)
+	upstreamFiles := map[string]string{".editorconfig": "upstream\n"}
+	srv := cmdTestServer(cmdTarball(checkTestPrefix, upstreamFiles))
+	t.Cleanup(srv.Close)
+	patchHTTP(t, srv)
+	_, _ = executeUpdateCmd(t, dir, "--check", "--source", "JoshLuedeman/teamwork")
+	data, err := os.ReadFile(filepath.Join(dir, ".editorconfig"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "local\n" {
+		t.Errorf("--check modified .editorconfig: got %q, want local", data)
 	}
 }

--- a/internal/installer/drift.go
+++ b/internal/installer/drift.go
@@ -1,0 +1,81 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// DriftResult describes the difference between installed and upstream framework files.
+type DriftResult struct {
+	Added    []string // files in upstream but not installed locally
+	Modified []string // files whose content differs between local and upstream
+	Removed  []string // files that are managed locally but no longer in upstream
+}
+
+// HasDrift reports whether any drift was detected.
+func (d *DriftResult) HasDrift() bool {
+	return len(d.Added) > 0 || len(d.Modified) > 0 || len(d.Removed) > 0
+}
+
+// CheckDrift downloads the latest tarball from upstream and compares framework
+// files against the currently installed versions in dir. It does NOT modify
+// any files on disk. Returns a DriftResult describing what would change.
+func CheckDrift(dir, owner, repo, ref string) (*DriftResult, error) {
+	upstreamFiles, _, err := fetchTarball(owner, repo, ref)
+	if err != nil {
+		return nil, fmt.Errorf("fetching tarball: %w", err)
+	}
+
+	// Apply the same language-file filter used by Install/Update so language-
+	// specific files for languages not present in dir are not counted as drift.
+	upstreamFiles = filterLanguageFiles(upstreamFiles, dir)
+
+	// Build a map of upstream files for fast lookup.
+	upstreamMap := make(map[string][]byte, len(upstreamFiles))
+	for _, f := range upstreamFiles {
+		upstreamMap[f.Path] = f.Data
+	}
+
+	// Read the manifest to know which files are framework-managed on disk.
+	manifest, err := readManifest(dir)
+	if err != nil {
+		// No manifest: treat as untracked install; check only by comparing files.
+		manifest = &Manifest{Files: make(map[string]string)}
+	}
+
+	result := &DriftResult{}
+
+	// Check each upstream file against the on-disk version.
+	for _, f := range upstreamFiles {
+		localPath := filepath.Join(dir, f.Path)
+		existing, readErr := os.ReadFile(localPath)
+		if readErr != nil {
+			// File does not exist locally - it would be added.
+			result.Added = append(result.Added, f.Path)
+			continue
+		}
+		if sha256hex(existing) != sha256hex(f.Data) {
+			result.Modified = append(result.Modified, f.Path)
+		}
+	}
+
+	// Check for files that are in the manifest (managed by framework) but
+	// no longer present in the upstream tarball - they would be removed.
+	for installedPath := range manifest.Files {
+		if _, inUpstream := upstreamMap[installedPath]; !inUpstream {
+			// Only flag as removed if the file still exists locally.
+			if _, statErr := os.Stat(filepath.Join(dir, installedPath)); statErr == nil {
+				result.Removed = append(result.Removed, installedPath)
+			}
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Strings(result.Added)
+	sort.Strings(result.Modified)
+	sort.Strings(result.Removed)
+
+	return result, nil
+}

--- a/internal/installer/drift_test.go
+++ b/internal/installer/drift_test.go
@@ -1,0 +1,186 @@
+package installer
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// serveAndCheckDrift calls CheckDrift() via a mock HTTP test server.
+func serveAndCheckDrift(t *testing.T, dir string, tb []byte) (*DriftResult, error) {
+	t.Helper()
+	srv := newTestServer(tb)
+	t.Cleanup(srv.Close)
+	original := http.DefaultTransport
+	http.DefaultTransport = &redirectTransport{target: srv.URL, base: &http.Transport{}}
+	t.Cleanup(func() { http.DefaultTransport = original })
+	return CheckDrift(dir, "JoshLuedeman", "teamwork", "main")
+}
+
+// TestCheckDrift_NoDrift verifies that identical local and upstream files produce no drift.
+func TestCheckDrift_NoDrift(t *testing.T) {
+	dir := t.TempDir()
+	tb := makeTarball(testPrefix, sampleFrameworkContent())
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("serveAndInstall: %v", err)
+	}
+	result, err := serveAndCheckDrift(t, dir, tb)
+	if err != nil {
+		t.Fatalf("CheckDrift: %v", err)
+	}
+	if result.HasDrift() {
+		t.Errorf("expected no drift, got Added=%v Modified=%v Removed=%v",
+			result.Added, result.Modified, result.Removed)
+	}
+}
+
+// TestCheckDrift_DetectsAddedFiles verifies files in upstream but not local are in Added.
+func TestCheckDrift_DetectsAddedFiles(t *testing.T) {
+	dir := t.TempDir()
+	baseFiles := sampleFrameworkContent()
+	tb := makeTarball(testPrefix, baseFiles)
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("serveAndInstall: %v", err)
+	}
+	newFile := ".github/agents/new-agent.agent.md"
+	upstreamFiles := make(map[string]string, len(baseFiles)+1)
+	for k, v := range baseFiles {
+		upstreamFiles[k] = v
+	}
+	upstreamFiles[newFile] = "# New Agent\n"
+	upstreamTb := makeTarball(testPrefix, upstreamFiles)
+	result, err := serveAndCheckDrift(t, dir, upstreamTb)
+	if err != nil {
+		t.Fatalf("CheckDrift: %v", err)
+	}
+	if !containsStr(result.Added, newFile) {
+		t.Errorf("expected %q in Added, got %v", newFile, result.Added)
+	}
+	if len(result.Modified) != 0 {
+		t.Errorf("expected no Modified, got %v", result.Modified)
+	}
+}
+
+// TestCheckDrift_DetectsModifiedFiles verifies content changes are in Modified.
+func TestCheckDrift_DetectsModifiedFiles(t *testing.T) {
+	dir := t.TempDir()
+	tb := makeTarball(testPrefix, sampleFrameworkContent())
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("serveAndInstall: %v", err)
+	}
+	modifiedFile := ".editorconfig"
+	if err := os.WriteFile(filepath.Join(dir, modifiedFile), []byte("# modified\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	result, err := serveAndCheckDrift(t, dir, tb)
+	if err != nil {
+		t.Fatalf("CheckDrift: %v", err)
+	}
+	if !containsStr(result.Modified, modifiedFile) {
+		t.Errorf("expected %q in Modified, got %v", modifiedFile, result.Modified)
+	}
+	if len(result.Added) != 0 {
+		t.Errorf("expected no Added, got %v", result.Added)
+	}
+}
+
+// TestCheckDrift_DetectsRemovedFiles verifies files dropped from upstream appear in Removed.
+func TestCheckDrift_DetectsRemovedFiles(t *testing.T) {
+	dir := t.TempDir()
+	baseFiles := sampleFrameworkContent()
+	tb := makeTarball(testPrefix, baseFiles)
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("serveAndInstall: %v", err)
+	}
+	removedFile := ".pre-commit-config.yaml"
+	upstreamFiles := make(map[string]string, len(baseFiles)-1)
+	for k, v := range baseFiles {
+		if k != removedFile {
+			upstreamFiles[k] = v
+		}
+	}
+	upstreamTb := makeTarball(testPrefix, upstreamFiles)
+	result, err := serveAndCheckDrift(t, dir, upstreamTb)
+	if err != nil {
+		t.Fatalf("CheckDrift: %v", err)
+	}
+	if !containsStr(result.Removed, removedFile) {
+		t.Errorf("expected %q in Removed, got %v", removedFile, result.Removed)
+	}
+	if len(result.Added) != 0 {
+		t.Errorf("expected no Added, got %v", result.Added)
+	}
+}
+
+// TestCheckDrift_NoDiskModification verifies CheckDrift does not write to disk.
+func TestCheckDrift_NoDiskModification(t *testing.T) {
+	dir := t.TempDir()
+	tb := makeTarball(testPrefix, sampleFrameworkContent())
+	if err := serveAndInstall(t, dir, tb); err != nil {
+		t.Fatalf("serveAndInstall: %v", err)
+	}
+	before := dirSnapshot(t, dir)
+	upstreamFiles := sampleFrameworkContent()
+	upstreamFiles[".github/agents/phantom.agent.md"] = "# Phantom\n"
+	upstreamTb := makeTarball(testPrefix, upstreamFiles)
+	if _, err := serveAndCheckDrift(t, dir, upstreamTb); err != nil {
+		t.Fatalf("CheckDrift: %v", err)
+	}
+	after := dirSnapshot(t, dir)
+	for path, content := range before {
+		if after[path] != content {
+			t.Errorf("file %q was modified by CheckDrift", path)
+		}
+	}
+	for path := range after {
+		if _, existed := before[path]; !existed {
+			t.Errorf("CheckDrift created unexpected file %q", path)
+		}
+	}
+}
+
+// TestCheckDrift_HasDrift_TrueWhenDrift verifies HasDrift returns true when there are changes.
+func TestCheckDrift_HasDrift_TrueWhenDrift(t *testing.T) {
+	d := &DriftResult{Added: []string{"new-file.md"}}
+	if !d.HasDrift() {
+		t.Error("HasDrift() should return true when Added is non-empty")
+	}
+}
+
+// TestCheckDrift_HasDrift_FalseWhenClean verifies HasDrift returns false when there are no changes.
+func TestCheckDrift_HasDrift_FalseWhenClean(t *testing.T) {
+	d := &DriftResult{}
+	if d.HasDrift() {
+		t.Error("HasDrift() should return false when no drift")
+	}
+}
+
+// dirSnapshot returns a map of relative path to content for all regular files in dir.
+func dirSnapshot(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	snap := make(map[string]string)
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		snap[rel] = string(data)
+		return nil
+	})
+	return snap
+}
+
+// containsStr reports whether needle is in haystack.
+func containsStr(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Closes #124

Adds a `--check` flag to `teamwork update` that downloads the latest upstream release and compares framework files against installed versions — **without modifying anything on disk**. Exits 1 if drift is detected, making it suitable for CI pipelines.

## Changes

### `internal/installer/drift.go` (new)
- `DriftResult` struct with `Added`, `Modified`, and `Removed` fields
- `HasDrift()` method for clean conditional checks
- `CheckDrift(dir, owner, repo, ref)` — downloads tarball, applies `filterLanguageFiles()` (same as `Update`), compares against local files and manifest

### `cmd/teamwork/cmd/update.go`
- Registers `--check` flag in `init()`
- Routes to `runDriftCheck()` when `--check` is set
- `runDriftCheck()` prints grouped diff summary (Added/Modified/Removed) and returns `ExitError{Code: 1}` when drift is found

### Tests
- 7 unit tests in `drift_test.go`: NoDrift, DetectsAdded, DetectsModified, DetectsRemoved, NoDiskModification, HasDrift true/false
- 3 cmd-level tests in `update_test.go`: NoDrift (exit 0), DriftDetected (exit 1), NoFilesModified (read-only check)

## Acceptance Criteria

- [x] `teamwork update --check` downloads latest release and compares
- [x] Reports added, modified, and removed files without making changes
- [x] Exits 1 when drift is detected
- [x] Exits 0 when no drift
- [x] No files are modified on disk during `--check`