### PR TITLE
fix(memory): remove duplicate test helper

### DIFF
--- a/internal/memory/sync_test.go
+++ b/internal/memory/sync_test.go
@@ -9,16 +9,6 @@ import (
 
 // setupMemoryDir creates a temp directory with the .teamwork/memory structure
 // and returns the root dir path.
-func setupMemoryDir(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	memDir := filepath.Join(dir, ".teamwork", "memory")
-	if err := os.MkdirAll(memDir, 0o755); err != nil {
-		t.Fatalf("creating memory dir: %v", err)
-	}
-	return dir
-}
-
 func TestSyncToMemoryMD_BasicContent(t *testing.T) {
 	dir := setupMemoryDir(t)
 


### PR DESCRIPTION
Removes the duplicate `setupMemoryDir` function from `sync_test.go` that already exists in `memory_test.go`, causing a build failure on `internal/memory` tests.\n\nThis was introduced when PRs #146 and #147 were merged — each added their own copy of the helper.