### PR TITLE
feat(installer): conditionally install api-agent for API projects

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -47,6 +47,31 @@ var languageInstructionFiles = map[string][]string{
 	".github/instructions/go.instructions.md": {"go.mod", "go.sum"},
 }
 
+// apiIndicatorFiles is the list of files whose presence suggests the project
+// exposes or consumes an API.
+var apiIndicatorFiles = []string{
+	"openapi.yaml",
+	"openapi.json",
+	"swagger.yaml",
+	"swagger.json",
+}
+
+// apiIndicatorDirs is the list of directory names whose presence suggests the
+// project has API-related code.
+var apiIndicatorDirs = []string{
+	"routes",
+	"api",
+	"handlers",
+}
+
+// apiFrameworkDeps is the list of npm package names that indicate an API
+// framework dependency.
+var apiFrameworkDeps = []string{
+	"express",
+	"fastify",
+	"koa",
+}
+
 // File represents a single file extracted from the tarball.
 type File struct {
 	Path string
@@ -77,6 +102,7 @@ func Install(dir, owner, repo, ref string) error {
 	}
 
 	files = filterLanguageFiles(files, dir)
+	files = filterApiAgentFiles(files, dir)
 
 	m := &Manifest{
 		Version: commitSHA,
@@ -156,6 +182,7 @@ func Update(dir, owner, repo, ref string, force bool) error {
 	}
 
 	files = filterLanguageFiles(files, dir)
+	files = filterApiAgentFiles(files, dir)
 
 	if currentVersion == commitSHA {
 		fmt.Println("Already up to date.")
@@ -577,6 +604,67 @@ func filterLanguageFiles(files []File, dir string) []File {
 		result = append(result, f)
 	}
 	return result
+}
+
+// filterApiAgentFiles removes the api-agent file when the project has no
+// detectable API indicators. An API indicator is any of: openapi.yaml/json,
+// swagger.yaml/json, a routes/, api/, or handlers/ directory at the root, or
+// a package.json that declares express, fastify, or koa as a dependency.
+func filterApiAgentFiles(files []File, dir string) []File {
+	if hasAPIIndicator(dir) {
+		return files
+	}
+	result := make([]File, 0, len(files))
+	for _, f := range files {
+		if f.Path == ".github/agents/api-agent.agent.md" {
+			continue
+		}
+		result = append(result, f)
+	}
+	return result
+}
+
+// hasAPIIndicator reports whether dir contains any signal that the project is API-related.
+func hasAPIIndicator(dir string) bool {
+	// Check for OpenAPI/Swagger spec files.
+	if hasAnyFile(dir, apiIndicatorFiles) {
+		return true
+	}
+	// Check for API-related directories.
+	for _, d := range apiIndicatorDirs {
+		info, err := os.Stat(filepath.Join(dir, d))
+		if err == nil && info.IsDir() {
+			return true
+		}
+	}
+	// Check for API framework in package.json dependencies.
+	return hasAPIFrameworkDep(dir)
+}
+
+// hasAPIFrameworkDep reports whether package.json in dir lists any of the
+// known API framework packages (express, fastify, koa) as a dependency.
+func hasAPIFrameworkDep(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	// Unmarshal only the relevant fields.
+	var pkg struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	for _, name := range apiFrameworkDeps {
+		if _, ok := pkg.Dependencies[name]; ok {
+			return true
+		}
+		if _, ok := pkg.DevDependencies[name]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // hasAnyFile reports whether any of the named files exist in dir.

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -1060,3 +1060,76 @@ func TestManifest_JSONRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// -- filterApiAgentFiles --
+
+func TestFilterApiAgentFiles_NoAPIIndicators_AgentRemoved(t *testing.T) {
+dir := t.TempDir()
+// No API indicators in dir.
+files := []File{
+{Path: ".github/agents/api-agent.agent.md", Data: []byte("# API Agent\n")},
+{Path: ".github/agents/coder.agent.md", Data: []byte("# Coder\n")},
+{Path: ".editorconfig", Data: []byte("root = true\n")},
+}
+got := filterApiAgentFiles(files, dir)
+for _, f := range got {
+if f.Path == ".github/agents/api-agent.agent.md" {
+t.Error("api-agent.agent.md should be removed when no API indicators are present")
+}
+}
+paths := make(map[string]bool)
+for _, f := range got {
+paths[f.Path] = true
+}
+if !paths[".github/agents/coder.agent.md"] {
+t.Error("coder.agent.md should not be removed")
+}
+}
+
+func TestFilterApiAgentFiles_WithOpenAPISpec_AgentRetained(t *testing.T) {
+dir := t.TempDir()
+if err := os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte("openapi: 3.0\n"), 0o644); err != nil {
+t.Fatalf("write openapi.yaml: %v", err)
+}
+files := []File{
+{Path: ".github/agents/api-agent.agent.md", Data: []byte("# API Agent\n")},
+}
+got := filterApiAgentFiles(files, dir)
+if len(got) != 1 || got[0].Path != ".github/agents/api-agent.agent.md" {
+t.Error("api-agent.agent.md should be retained when openapi.yaml is present")
+}
+}
+
+func TestFilterApiAgentFiles_WithRoutesDir_AgentRetained(t *testing.T) {
+dir := t.TempDir()
+if err := os.MkdirAll(filepath.Join(dir, "routes"), 0o755); err != nil {
+t.Fatalf("mkdir routes: %v", err)
+}
+files := []File{
+{Path: ".github/agents/api-agent.agent.md", Data: []byte("# API Agent\n")},
+{Path: ".editorconfig", Data: []byte("root = true\n")},
+}
+got := filterApiAgentFiles(files, dir)
+paths := make(map[string]bool)
+for _, f := range got {
+paths[f.Path] = true
+}
+if !paths[".github/agents/api-agent.agent.md"] {
+t.Error("api-agent.agent.md should be retained when routes/ directory is present")
+}
+}
+
+func TestFilterApiAgentFiles_WithExpressInPackageJSON_AgentRetained(t *testing.T) {
+dir := t.TempDir()
+pkgJSON := `{"name":"app","dependencies":{"express":"^4.18.0","lodash":"^4.0.0"}}`
+if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644); err != nil {
+t.Fatalf("write package.json: %v", err)
+}
+files := []File{
+{Path: ".github/agents/api-agent.agent.md", Data: []byte("# API Agent\n")},
+}
+got := filterApiAgentFiles(files, dir)
+if len(got) != 1 {
+t.Errorf("expected 1 file, got %d — api-agent should be retained when express is a dependency", len(got))
+}
+}


### PR DESCRIPTION
Closes #137

Only installs the api-agent when the project shows API indicators (OpenAPI spec, routes/ directory, or API framework in package.json).