### PR TITLE
feat(gates): implement pluggable quality gate hooks

### DIFF
--- a/internal/gates/gates.go
+++ b/internal/gates/gates.go
@@ -1,55 +1,78 @@
+// Package gates provides utilities for running custom quality gate scripts
+// during the workflow handoff process.
+//
+// Gate scripts are shell commands configured under extra_gates in
+// .teamwork/config.yaml. Each script is executed with the workflow directory
+// as the working directory and must exit 0 to pass.
 package gates
 
 import (
+"bytes"
+"context"
 "fmt"
 "os/exec"
+"strings"
+"time"
 )
 
-type Runner interface {
-Run(command, dir string) ([]byte, error)
+// gateTimeout is the maximum time a single gate script may run.
+const gateTimeout = 30 * time.Second
+
+// GateFailure records a gate script that exited non-zero.
+type GateFailure struct {
+Script string
+Output string
 }
 
-type ShellRunner struct{}
+// RunGate executes a single gate script and reports whether it passed.
+//
+// The script is run via "sh -c <script>" with dir as the working directory.
+// Gate passes when exit code is 0. Combined stdout+stderr is returned as
+// output regardless of pass/fail.
+func RunGate(dir, script string) (passed bool, output string, err error) {
+ctx, cancel := context.WithTimeout(context.Background(), gateTimeout)
+defer cancel()
 
-func (ShellRunner) Run(command, dir string) ([]byte, error) {
-cmd := exec.Command("/bin/sh", "-c", command)
+cmd := exec.CommandContext(ctx, "sh", "-c", script)
 cmd.Dir = dir
-return cmd.CombinedOutput()
+
+var buf bytes.Buffer
+cmd.Stdout = &buf
+cmd.Stderr = &buf
+
+runErr := cmd.Run()
+output = strings.TrimRight(buf.String(), "\n")
+
+if ctx.Err() != nil {
+return false, output, fmt.Errorf("gates: script %q timed out after %s", script, gateTimeout)
 }
 
-type GateResult struct {
-Condition string
-Output    string
-Passed    bool
+if runErr != nil {
+// A non-zero exit is a gate failure, not a Go-level error.
+if _, ok := runErr.(*exec.ExitError); ok {
+return false, output, nil
+}
+return false, output, fmt.Errorf("gates: run %q: %w", script, runErr)
 }
 
-func GateKey(step int) string {
-return fmt.Sprintf("after_step_%d", step)
+return true, output, nil
 }
 
-func Lookup(extraGates map[string]map[string][]string, workflowType, location string) []string {
-if extraGates == nil {
-return nil
+// RunAll executes all gate scripts in order and collects every failure.
+//
+// Execution continues past individual gate failures so all results are
+// reported at once. A non-nil err is returned only when a script cannot be
+// invoked at all (e.g. "sh" is not on PATH). Gate exit-code failures appear
+// in the returned failures slice.
+func RunAll(dir string, scripts []string) (failures []GateFailure, err error) {
+for _, script := range scripts {
+passed, output, runErr := RunGate(dir, script)
+if runErr != nil {
+return failures, runErr
 }
-locs, ok := extraGates[workflowType]
-if !ok {
-return nil
+if !passed {
+failures = append(failures, GateFailure{Script: script, Output: output})
 }
-return locs[location]
 }
-
-func RunGate(location string, conditions []string, dir string, runner Runner) ([]GateResult, bool, error) {
-var results []GateResult
-for _, cond := range conditions {
-out, err := runner.Run(cond, dir)
-if err != nil {
-if _, ok := err.(*exec.ExitError); ok {
-results = append(results, GateResult{Condition: cond, Output: string(out), Passed: false})
-return results, false, nil
-}
-return results, false, fmt.Errorf("gates: run %q: %w", cond, err)
-}
-results = append(results, GateResult{Condition: cond, Output: string(out), Passed: true})
-}
-return results, true, nil
+return failures, nil
 }

--- a/internal/gates/gates_test.go
+++ b/internal/gates/gates_test.go
@@ -1,87 +1,148 @@
-package gates
+package gates_test
 
 import (
-"fmt"
-"os/exec"
+"os"
+"path/filepath"
 "testing"
+
+"github.com/joshluedeman/teamwork/internal/gates"
 )
 
-type mockRunner struct {
-calls   []string
-outputs []string
-errs    []error
-idx     int
+// writeScript creates an executable shell script in dir and returns its path.
+func writeScript(t *testing.T, dir, name, body string) string {
+t.Helper()
+path := filepath.Join(dir, name)
+if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+t.Fatalf("writeScript: %v", err)
+}
+return path
 }
 
-func (m *mockRunner) Run(command, dir string) ([]byte, error) {
-m.calls = append(m.calls, command)
-i := m.idx
-m.idx++
-var out string
-if i < len(m.outputs) {
-out = m.outputs[i]
+func TestRunGate_Passes(t *testing.T) {
+dir := t.TempDir()
+script := writeScript(t, dir, "pass.sh", "exit 0")
+
+passed, output, err := gates.RunGate(dir, script)
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
 }
-if i < len(m.errs) && m.errs[i] != nil {
-return []byte(out), m.errs[i]
+if !passed {
+t.Errorf("expected gate to pass, got output: %q", output)
 }
-return []byte(out), nil
 }
 
-func TestRunGateAllPass(t *testing.T) {
-m := &mockRunner{outputs: []string{"ok1", "ok2"}, errs: []error{nil, nil}}
-results, passed, err := RunGate("after_step_1", []string{"cmd1", "cmd2"}, "/tmp", m)
-if err != nil { t.Fatalf("unexpected: %v", err) }
-if !passed { t.Fatal("expected pass") }
-if len(results) != 2 { t.Fatalf("got %d", len(results)) }
-if len(m.calls) != 2 { t.Fatalf("got %d calls", len(m.calls)) }
+func TestRunGate_Fails(t *testing.T) {
+dir := t.TempDir()
+script := writeScript(t, dir, "fail.sh", "echo 'lint error'; exit 1")
+
+passed, output, err := gates.RunGate(dir, script)
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if passed {
+t.Error("expected gate to fail, but it passed")
+}
+if output == "" {
+t.Error("expected non-empty output from failing gate")
+}
 }
 
-func TestRunGateFirstFails(t *testing.T) {
-m := &mockRunner{outputs: []string{"fail"}, errs: []error{&exec.ExitError{}}}
-results, passed, err := RunGate("after_step_1", []string{"bad", "good"}, "/tmp", m)
-if err != nil { t.Fatalf("unexpected: %v", err) }
-if passed { t.Fatal("expected failure") }
-if len(results) != 1 { t.Fatalf("got %d", len(results)) }
-if len(m.calls) != 1 { t.Fatalf("got %d calls", len(m.calls)) }
+func TestRunGate_CapturesOutput(t *testing.T) {
+dir := t.TempDir()
+script := writeScript(t, dir, "output.sh", "echo 'hello from gate'")
+
+_, output, err := gates.RunGate(dir, script)
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if output != "hello from gate" {
+t.Errorf("unexpected output: %q", output)
+}
 }
 
-func TestRunGateSecondFails(t *testing.T) {
-m := &mockRunner{outputs: []string{"ok", "fail"}, errs: []error{nil, &exec.ExitError{}}}
-_, passed, err := RunGate("after_step_1", []string{"good", "bad"}, "/tmp", m)
-if err != nil { t.Fatalf("unexpected: %v", err) }
-if passed { t.Fatal("expected failure") }
+func TestRunGate_UsesWorkingDir(t *testing.T) {
+dir := t.TempDir()
+// Create a sentinel file so the script can assert it runs in the right dir.
+if err := os.WriteFile(filepath.Join(dir, "sentinel.txt"), []byte(""), 0o644); err != nil {
+t.Fatal(err)
+}
+script := writeScript(t, dir, "pwd_check.sh", "test -f sentinel.txt")
+
+passed, _, err := gates.RunGate(dir, script)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if !passed {
+t.Error("gate should have found sentinel.txt in working dir")
+}
 }
 
-func TestRunGateEmptyConditions(t *testing.T) {
-m := &mockRunner{}
-results, passed, err := RunGate("after_step_1", []string{}, "/tmp", m)
-if err != nil { t.Fatalf("unexpected: %v", err) }
-if !passed { t.Fatal("should pass") }
-if len(results) != 0 { t.Fatalf("got %d", len(results)) }
+func TestRunAll_AllPass(t *testing.T) {
+dir := t.TempDir()
+s1 := writeScript(t, dir, "a.sh", "exit 0")
+s2 := writeScript(t, dir, "b.sh", "exit 0")
+
+failures, err := gates.RunAll(dir, []string{s1, s2})
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(failures) != 0 {
+t.Errorf("expected no failures, got %d: %+v", len(failures), failures)
+}
 }
 
-func TestGateKey(t *testing.T) {
-if got := GateKey(1); got != "after_step_1" { t.Errorf("got %q", got) }
-if got := GateKey(3); got != "after_step_3" { t.Errorf("got %q", got) }
+func TestRunAll_MixedPassFail(t *testing.T) {
+dir := t.TempDir()
+pass := writeScript(t, dir, "pass.sh", "exit 0")
+fail1 := writeScript(t, dir, "fail1.sh", "echo 'err1'; exit 1")
+fail2 := writeScript(t, dir, "fail2.sh", "echo 'err2'; exit 2")
+
+failures, err := gates.RunAll(dir, []string{pass, fail1, fail2})
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(failures) != 2 {
+t.Fatalf("expected 2 failures, got %d: %+v", len(failures), failures)
+}
+if failures[0].Script != fail1 {
+t.Errorf("expected first failure script %q, got %q", fail1, failures[0].Script)
+}
+if failures[1].Script != fail2 {
+t.Errorf("expected second failure script %q, got %q", fail2, failures[1].Script)
+}
 }
 
-func TestLookup(t *testing.T) {
-g := map[string]map[string][]string{"feature": {"after_step_2": {"lint", "test"}}}
-if got := Lookup(g, "feature", "after_step_2"); len(got) != 2 { t.Fatalf("got %v", got) }
-if Lookup(g, "bugfix", "after_step_2") != nil { t.Fatal("wrong type") }
-if Lookup(g, "feature", "after_step_1") != nil { t.Fatal("wrong loc") }
-if Lookup(nil, "feature", "after_step_2") != nil { t.Fatal("nil") }
+func TestRunAll_Empty(t *testing.T) {
+dir := t.TempDir()
+
+failures, err := gates.RunAll(dir, nil)
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(failures) != 0 {
+t.Errorf("expected no failures for empty scripts, got %d", len(failures))
+}
 }
 
-func TestShellRunnerIntegration(t *testing.T) {
-r := ShellRunner{}
-out, err := r.Run("echo hello", t.TempDir())
-if err != nil { t.Fatalf("unexpected: %v", err) }
-if string(out) != "hello\n" { t.Errorf("got %q", string(out)) }
-_, err = r.Run("exit 1", t.TempDir())
-if err == nil { t.Fatal("expected error") }
-if _, ok := err.(*exec.ExitError); !ok { t.Fatalf("got %T", err) }
-out, err = r.Run(fmt.Sprintf("echo fail && exit 1"), t.TempDir())
-if err == nil { t.Fatal("expected error") }
-if string(out) != "fail\n" { t.Errorf("got %q", string(out)) }
+func TestRunAll_CollectsAllFailures(t *testing.T) {
+dir := t.TempDir()
+// Ensure RunAll doesn't short-circuit after first failure.
+s0 := writeScript(t, dir, "f0.sh", "exit 1")
+s1 := writeScript(t, dir, "f1.sh", "exit 1")
+s2 := writeScript(t, dir, "f2.sh", "exit 1")
+
+failures, err := gates.RunAll(dir, []string{s0, s1, s2})
+
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(failures) != 3 {
+t.Errorf("expected 3 failures, got %d", len(failures))
+}
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -19,9 +19,8 @@ import (
 
 // Engine manages workflow execution by coordinating state, handoffs, and metrics.
 type Engine struct {
-	Dir        string         // project root directory
-	Config     *config.Config // parsed .teamwork/config.yaml
-	GateRunner gates.Runner   // optional runner for extra quality gates
+	Dir    string         // project root directory
+	Config *config.Config // parsed .teamwork/config.yaml
 }
 
 // StepInfo describes a single step within a workflow definition.
@@ -344,17 +343,22 @@ func (e *Engine) Handoff(workflowID string, artifact *handoff.Artifact) error {
 		durationSec = int(time.Since(startedAt).Seconds())
 	}
 
-	// Run extra quality gates if configured.
-	if e.GateRunner != nil && e.Config != nil {
-		location := gates.GateKey(ws.CurrentStep)
-		conditions := gates.Lookup(e.Config.Workflows.ExtraGates, ws.Type, location)
-		if len(conditions) > 0 {
-			_, passed, err := gates.RunGate(location, conditions, e.Dir, e.GateRunner)
-			if err != nil {
-				return fmt.Errorf("workflow: run extra gate: %w", err)
+	// Run extra quality gates if configured for this workflow type and step.
+	if e.Config != nil && len(e.Config.Workflows.ExtraGates) > 0 {
+		scripts := e.Config.Workflows.ExtraGates[ws.Type][ws.CurrentRole]
+		if len(scripts) > 0 {
+			failures, gateErr := gates.RunAll(e.Dir, scripts)
+			if gateErr != nil {
+				return fmt.Errorf("workflow: run extra gate: %w", gateErr)
 			}
-			if !passed {
-				return fmt.Errorf("workflow: extra gate failed at %s", location)
+			for _, f := range failures {
+				_ = metrics.LogGate(e.Dir, workflowID, ws.CurrentStep, ws.CurrentRole, f.Script, "failed")
+			}
+			if len(failures) > 0 {
+				return fmt.Errorf("workflow: extra gate %q failed: %s", failures[0].Script, failures[0].Output)
+			}
+			for _, script := range scripts {
+				_ = metrics.LogGate(e.Dir, workflowID, ws.CurrentStep, ws.CurrentRole, script, "passed")
 			}
 		}
 	}

--- a/internal/workflow/engine_gates_test.go
+++ b/internal/workflow/engine_gates_test.go
@@ -1,138 +1,173 @@
 package workflow
 
 import (
+"fmt"
 "os"
-"os/exec"
 "path/filepath"
 "strings"
 "testing"
 "time"
 
 "github.com/joshluedeman/teamwork/internal/config"
-"github.com/joshluedeman/teamwork/internal/gates"
 "github.com/joshluedeman/teamwork/internal/handoff"
 "github.com/joshluedeman/teamwork/internal/state"
 )
 
-func realExitError() *exec.ExitError {
-err := exec.Command("/bin/sh", "-c", "exit 1").Run()
-ee, _ := err.(*exec.ExitError)
-return ee
+// writeGateScript creates an executable shell script in dir with the given body
+// and returns its absolute path.
+func writeGateScript(t *testing.T, dir, name, body string) string {
+t.Helper()
+path := filepath.Join(dir, name)
+if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+t.Fatalf("writeGateScript: %v", err)
+}
+return path
 }
 
-type mockGateRunner struct {
-calls   []string
-outputs []string
-errs    []error
-idx     int
-}
-
-func (m *mockGateRunner) Run(command, dir string) ([]byte, error) {
-m.calls = append(m.calls, command)
-i := m.idx
-m.idx++
-var out string
-if i < len(m.outputs) {
-out = m.outputs[i]
-}
-if i < len(m.errs) && m.errs[i] != nil {
-return []byte(out), m.errs[i]
-}
-return []byte(out), nil
-}
-
-func setupEngineWithGates(t *testing.T, extraGates map[string]map[string][]string, runner gates.Runner) (*Engine, string) {
+// setupEngineWithGates builds a temp Engine whose ExtraGates are keyed by
+// [workflowType][role] and points at real shell scripts.
+func setupEngineWithGates(t *testing.T, extraGates map[string]map[string][]string) (*Engine, string) {
 t.Helper()
 dir := t.TempDir()
-twDir := filepath.Join(dir, ".teamwork")
-if err := os.MkdirAll(twDir, 0o755); err != nil { t.Fatal(err) }
-cfgYAML := "project_name: test\nworkflows:\n  extra_gates: {}\n"
-if err := os.WriteFile(filepath.Join(twDir, "config.yaml"), []byte(cfgYAML), 0o644); err != nil { t.Fatal(err) }
-if err := os.MkdirAll(filepath.Join(twDir, "metrics"), 0o755); err != nil { t.Fatal(err) }
-if err := os.MkdirAll(filepath.Join(twDir, "handoffs"), 0o755); err != nil { t.Fatal(err) }
-cfg, err := config.Load(dir)
-if err != nil { t.Fatal(err) }
+for _, sub := range []string{"state/feature", "handoffs", "metrics"} {
+if err := os.MkdirAll(filepath.Join(dir, ".teamwork", sub), 0o755); err != nil {
+t.Fatalf("mkdir: %v", err)
+}
+}
+cfg := config.Default()
+// Disable standard quality gates so tests focus on extra gates only.
+cfg.QualityGates.TestsPass = false
+cfg.QualityGates.LintPass = false
 cfg.Workflows.ExtraGates = extraGates
-return &Engine{Dir: dir, Config: cfg, GateRunner: runner}, dir
+return &Engine{Dir: dir, Config: cfg}, dir
 }
 
-func makeTestArtifact(wfID string, step int, role, nextRole string) *handoff.Artifact {
+// makeGateArtifact returns a valid handoff artifact for step 1 / planner.
+func makeGateArtifact(wfID string) *handoff.Artifact {
 return &handoff.Artifact{
-WorkflowID: wfID, Step: step, Role: role, NextRole: nextRole,
-Date: time.Now().Format(time.RFC3339), Summary: "test", Context: "ctx",
+WorkflowID: wfID,
+Step:       1,
+Role:       "planner",
+NextRole:   "architect",
+Date:       time.Now().Format(time.RFC3339),
+Summary:    "gate test handoff",
+Context:    "ctx",
 }
 }
 
-func createTestWorkflow(t *testing.T, dir, wfID, wfType string, step int, role string) {
+// createGateWorkflow seeds the .teamwork/state tree with an active workflow at
+// step 1, role "planner".
+func createGateWorkflow(t *testing.T, dir, wfID, wfType string) {
 t.Helper()
+subDir := filepath.Join(dir, ".teamwork", "state", filepath.Dir(wfID))
+if err := os.MkdirAll(subDir, 0o755); err != nil {
+t.Fatalf("mkdir state: %v", err)
+}
 ws := &state.WorkflowState{
-ID: wfID, Type: wfType, Status: state.StatusActive,
-CurrentStep: step, CurrentRole: role, Goal: "test", Branch: wfID,
-Steps: []state.StepRecord{{Step: step, Role: role, Started: time.Now().Format(time.RFC3339)}},
+ID:          wfID,
+Type:        wfType,
+Status:      state.StatusActive,
+CurrentStep: 1,
+CurrentRole: "planner",
+Goal:        "test",
+Branch:      wfID,
+Steps: []state.StepRecord{
+{Step: 1, Role: "planner", Started: time.Now().Format(time.RFC3339)},
+},
 }
-if err := ws.Save(dir); err != nil { t.Fatal(err) }
+if err := ws.Save(dir); err != nil {
+t.Fatalf("save state: %v", err)
 }
-
-func TestExtraGatesPass(t *testing.T) {
-r := &mockGateRunner{outputs: []string{"ok1", "ok2"}, errs: []error{nil, nil}}
-eg := map[string]map[string][]string{"feature": {"after_step_1": {"lint", "test"}}}
-e, dir := setupEngineWithGates(t, eg, r)
-createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
-err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
-if err != nil { t.Fatalf("expected success: %v", err) }
-if len(r.calls) != 2 { t.Fatalf("expected 2 calls, got %d", len(r.calls)) }
-ws, _ := state.Load(dir, "feature-42-x")
-if ws.CurrentStep != 2 { t.Fatalf("expected step 2, got %d", ws.CurrentStep) }
 }
 
-func TestExtraGatesFail(t *testing.T) {
-r := &mockGateRunner{outputs: []string{"ok", "FAIL"}, errs: []error{nil, realExitError()}}
-eg := map[string]map[string][]string{"feature": {"after_step_1": {"lint", "test"}}}
-e, dir := setupEngineWithGates(t, eg, r)
-createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
-err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
-if err == nil { t.Fatal("expected error") }
-if !strings.Contains(err.Error(), "extra gate") { t.Fatalf("wrong error: %v", err) }
-ws, _ := state.Load(dir, "feature-42-x")
-if ws.CurrentStep != 1 { t.Fatalf("expected step 1, got %d", ws.CurrentStep) }
+func TestExtraGates_AllPass(t *testing.T) {
+dir := t.TempDir()
+pass1 := writeGateScript(t, dir, "pass1.sh", "exit 0")
+pass2 := writeGateScript(t, dir, "pass2.sh", "exit 0")
+eg := map[string]map[string][]string{
+"feature": {"planner": {pass1, pass2}},
+}
+e, eDir := setupEngineWithGates(t, eg)
+createGateWorkflow(t, eDir, "feature/42", "feature")
+
+err := e.Handoff("feature/42", makeGateArtifact("feature/42"))
+if err != nil {
+t.Fatalf("Handoff() unexpected error: %v", err)
 }
 
-func TestExtraGatesNoGatesConfigured(t *testing.T) {
-r := &mockGateRunner{}
-e, dir := setupEngineWithGates(t, nil, r)
-createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
-err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
-if err != nil { t.Fatalf("expected success: %v", err) }
-if len(r.calls) != 0 { t.Fatalf("expected 0 calls, got %d", len(r.calls)) }
+// Workflow should have advanced to step 2.
+ws, _ := state.Load(eDir, "feature/42")
+if ws.CurrentStep != 2 {
+t.Errorf("expected CurrentStep=2, got %d", ws.CurrentStep)
+}
 }
 
-func TestExtraGatesWrongStep(t *testing.T) {
-r := &mockGateRunner{}
-eg := map[string]map[string][]string{"feature": {"after_step_2": {"no"}}}
-e, dir := setupEngineWithGates(t, eg, r)
-createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
-err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
-if err != nil { t.Fatalf("expected success: %v", err) }
-if len(r.calls) != 0 { t.Fatalf("expected 0 calls, got %d", len(r.calls)) }
+func TestExtraGates_OneFails_HandoffRejected(t *testing.T) {
+dir := t.TempDir()
+pass := writeGateScript(t, dir, "pass.sh", "exit 0")
+fail := writeGateScript(t, dir, "fail.sh", fmt.Sprintf("echo 'gate output from %s'; exit 1", "fail.sh"))
+eg := map[string]map[string][]string{
+"feature": {"planner": {pass, fail}},
+}
+e, eDir := setupEngineWithGates(t, eg)
+createGateWorkflow(t, eDir, "feature/43", "feature")
+
+err := e.Handoff("feature/43", makeGateArtifact("feature/43"))
+if err == nil {
+t.Fatal("Handoff() should have returned an error when an extra gate fails")
+}
+if !strings.Contains(err.Error(), "extra gate") {
+t.Errorf("error %q should mention 'extra gate'", err.Error())
+}
+if !strings.Contains(err.Error(), "fail.sh") {
+t.Errorf("error %q should identify the failed script", err.Error())
 }
 
-func TestExtraGatesWrongWorkflowType(t *testing.T) {
-r := &mockGateRunner{}
-eg := map[string]map[string][]string{"bugfix": {"after_step_1": {"no"}}}
-e, dir := setupEngineWithGates(t, eg, r)
-createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
-err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
-if err != nil { t.Fatalf("expected success: %v", err) }
-if len(r.calls) != 0 { t.Fatalf("expected 0 calls, got %d", len(r.calls)) }
+// Workflow must remain on step 1 (handoff was rejected).
+ws, _ := state.Load(eDir, "feature/43")
+if ws.CurrentStep != 1 {
+t.Errorf("expected CurrentStep=1 after rejection, got %d", ws.CurrentStep)
+}
 }
 
-func TestExtraGatesFirstCommandFails(t *testing.T) {
-r := &mockGateRunner{outputs: []string{"FAIL"}, errs: []error{realExitError()}}
-eg := map[string]map[string][]string{"feature": {"after_step_1": {"bad", "good"}}}
-e, dir := setupEngineWithGates(t, eg, r)
-createTestWorkflow(t, dir, "feature-42-x", "feature", 1, "planner")
-err := e.Handoff("feature-42-x", makeTestArtifact("feature-42-x", 1, "planner", "coder"))
-if err == nil { t.Fatal("expected error") }
-if len(r.calls) != 1 { t.Fatalf("expected 1 call, got %d", len(r.calls)) }
-if r.calls[0] != "bad" { t.Fatalf("expected bad, got %q", r.calls[0]) }
+func TestExtraGates_NilExtraGates_SkipsSilently(t *testing.T) {
+e, eDir := setupEngineWithGates(t, nil)
+createGateWorkflow(t, eDir, "feature/44", "feature")
+
+err := e.Handoff("feature/44", makeGateArtifact("feature/44"))
+if err != nil {
+t.Fatalf("Handoff() with nil ExtraGates: %v", err)
+}
+}
+
+func TestExtraGates_WrongWorkflowType_SkipsSilently(t *testing.T) {
+dir := t.TempDir()
+alwaysFail := writeGateScript(t, dir, "fail.sh", "exit 1")
+// Gate is configured for "bugfix" but workflow is "feature".
+eg := map[string]map[string][]string{
+"bugfix": {"planner": {alwaysFail}},
+}
+e, eDir := setupEngineWithGates(t, eg)
+createGateWorkflow(t, eDir, "feature/45", "feature")
+
+err := e.Handoff("feature/45", makeGateArtifact("feature/45"))
+if err != nil {
+t.Fatalf("Handoff() should succeed when no gates match workflow type: %v", err)
+}
+}
+
+func TestExtraGates_WrongRole_SkipsSilently(t *testing.T) {
+dir := t.TempDir()
+alwaysFail := writeGateScript(t, dir, "fail.sh", "exit 1")
+// Gate is configured for "coder" but current role is "planner".
+eg := map[string]map[string][]string{
+"feature": {"coder": {alwaysFail}},
+}
+e, eDir := setupEngineWithGates(t, eg)
+createGateWorkflow(t, eDir, "feature/46", "feature")
+
+err := e.Handoff("feature/46", makeGateArtifact("feature/46"))
+if err != nil {
+t.Fatalf("Handoff() should succeed when no gates match current role: %v", err)
+}
 }

--- a/mcp-servers/complexity/tests/fixtures/complex.go
+++ b/mcp-servers/complexity/tests/fixtures/complex.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 func complexFunction(x int, y int, z int) int {


### PR DESCRIPTION
Closes #115

Implements the `extra_gates` config field by running custom scripts during handoff. Gates run after `tests_pass`/`lint_pass` checks and block handoff if any script exits non-zero.

## What changed

- **`internal/gates/gates.go`** — new pure-function API:
  - `RunGate(dir, script string) (bool, string, error)` — runs one script via `sh -c`, 30 s timeout
  - `RunAll(dir string, scripts []string) ([]GateFailure, error)` — runs all, collecting all failures (doesn't short-circuit)
- **`internal/workflow/engine.go`** — Handoff() now looks up `cfg.ExtraGates[workflowType][currentRole]` and calls `gates.RunAll`; failures are logged via `metrics.LogGate` and block the handoff with a descriptive error
- **`internal/gates/gates_test.go`** — unit tests using real temp shell scripts (pass, fail, output capture, working dir, RunAll mix)
- **`internal/workflow/engine_gates_test.go`** — integration tests: gate passes advances workflow, gate fails keeps step, nil/wrong-type/wrong-role skips silently
- **`mcp-servers/complexity/tests/fixtures/complex.go`** — added `//go:build ignore` to fix pre-existing `go build ./...` failure